### PR TITLE
Fix import for EvoMergeSampler

### DIFF
--- a/package/samplers/evo_merge/sampler.py
+++ b/package/samplers/evo_merge/sampler.py
@@ -22,7 +22,7 @@ from transformers import BitsAndBytesConfig
 from transformers import pipeline
 import yaml
 
-from package.samplers.evo_merge.trial import EvoMergeTrial
+from .trial import EvoMergeTrial
 
 
 class EvoMergeSampler(BaseSampler):


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
The current EvoMergeSampler cannot be imported from outside of this repo. This PR fixes the import.

## Description of the changes
<!-- Describe the changes in this PR. -->
