### PR TITLE
Add median pruner

### DIFF
--- a/package/pruners/median/LICENSE
+++ b/package/pruners/median/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Preferred Networks, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/pruners/median/README.md
+++ b/package/pruners/median/README.md
@@ -1,0 +1,37 @@
+---
+author: 'Optuna team'
+title: 'Median Pruner'
+description: 'Pruner using the median stopping rule.'
+tags: ['pruner', 'built-in']
+optuna_versions: ['3.6.1']
+license: 'MIT License'
+---
+
+## Class or Function Names
+- MedianPruner
+
+## Example
+```python
+import optuna
+from optuna.pruners import MedianPruner
+
+
+def objective(trial):
+    s = 0
+    for step in range(20):
+       x = trial.suggest_float(f"x_{step}", -5, 5)
+       s += x**2
+       trial.report(s, step)
+       if trial.should_prune():
+            raise optuna.TrialPruned()
+    return s
+
+
+pruner = MedianPruner()
+study = optuna.create_study(pruner=pruner)
+study.optimize(objective, n_trials=20)
+```
+
+## Others
+See the [documentation](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.MedianPruner.html) for more details.
+


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

## Motivation

- This PR aims to add the `pruner` category in addition to `sampler` and `visualization`

## Description of the changes

- Create the`package/pruners` directory
- Add `MedianPruner` as an example

## Screenshots

*List*
<img width="1102" alt="image" src="https://github.com/optuna/optunahub-registry/assets/3255979/41261239-03c8-4c35-814a-266ef53e8282">

*Tag*
<img width="803" alt="image" src="https://github.com/optuna/optunahub-registry/assets/3255979/28baad60-dd46-45b6-859f-439922944ef9">

*Details*
<img width="1117" alt="image" src="https://github.com/optuna/optunahub-registry/assets/3255979/d7558739-b5c6-4591-878c-bf829f5c87f6">
