### PR TITLE
Add support for Pythonic search space to `SimpleSampler`

### DIFF
--- a/package/samplers/hebo/sampler.py
+++ b/package/samplers/hebo/sampler.py
@@ -17,17 +17,22 @@ from hebo.design_space.design_space import DesignSpace
 from hebo.optimizers.hebo import HEBO
 
 
-SimpleSampler = optunahub.load_module("samplers/simple").SimpleSampler
+SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
 
 
-class HEBOSampler(SimpleSampler):  # type: ignore
-    def __init__(self, search_space: dict[str, BaseDistribution]) -> None:
+class HEBOSampler(SimpleBaseSampler):  # type: ignore
+    def __init__(self, search_space: dict[str, BaseDistribution] | None = None) -> None:
         super().__init__(search_space)
-        self._hebo = HEBO(self._convert_to_hebo_design_space(search_space))
+        self._hebo = None
 
     def sample_relative(
         self, study: Study, trial: FrozenTrial, search_space: dict[str, BaseDistribution]
     ) -> dict[str, float]:
+        if len(search_space) == 0:
+            return {}
+        if self._hebo is None:
+            self._hebo = HEBO(self._convert_to_hebo_design_space(search_space))
+        assert self._hebo is not None
         params_pd = self._hebo.suggest()
 
         params = {}

--- a/package/samplers/hebo/sampler.py
+++ b/package/samplers/hebo/sampler.py
@@ -21,18 +21,13 @@ SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
 
 
 class HEBOSampler(SimpleBaseSampler):  # type: ignore
-    def __init__(self, search_space: dict[str, BaseDistribution] | None = None) -> None:
+    def __init__(self, search_space: dict[str, BaseDistribution]) -> None:
         super().__init__(search_space)
-        self._hebo = None
+        self._hebo = HEBO(self._convert_to_hebo_design_space(search_space))
 
     def sample_relative(
         self, study: Study, trial: FrozenTrial, search_space: dict[str, BaseDistribution]
     ) -> dict[str, float]:
-        if len(search_space) == 0:
-            return {}
-        if self._hebo is None:
-            self._hebo = HEBO(self._convert_to_hebo_design_space(search_space))
-        assert self._hebo is not None
         params_pd = self._hebo.suggest()
 
         params = {}

--- a/package/samplers/plmbo/example.py
+++ b/package/samplers/plmbo/example.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import matplotlib.pyplot as plt
 import numpy as np
 import optuna
-from optuna.distributions import FloatDistribution
 import optunahub
 
 
@@ -35,13 +34,7 @@ if __name__ == "__main__":
         values = obs_obj_func(np.array([x1, x2]))
         return float(values[0]), float(values[1])
 
-    sampler = PLMBOSampler(
-        {
-            "x1": FloatDistribution(0, 1),
-            "x2": FloatDistribution(0, 1),
-        }
-    )
-    study = optuna.create_study(sampler=sampler, directions=["minimize", "minimize"])
+    study = optuna.create_study(sampler=PLMBOSampler(), directions=["minimize", "minimize"])
     study.optimize(objective, n_trials=20)
 
     optuna.visualization.matplotlib.plot_pareto_front(study)

--- a/package/samplers/plmbo/plmbo.py
+++ b/package/samplers/plmbo/plmbo.py
@@ -20,10 +20,10 @@ import optunahub
 from scipy import optimize  # type: ignore
 
 
-class PLMBOSampler(optunahub.load_module("samplers/simple").SimpleSampler):  # type: ignore
+class PLMBOSampler(optunahub.load_module("samplers/simple").SimpleBaseSampler):  # type: ignore
     def __init__(
         self,
-        search_space: dict[str, BaseDistribution],
+        search_space: dict[str, BaseDistribution] | None = None,
         *,
         seed: int | None = None,
         independent_sampler: BaseSampler | None = None,
@@ -50,6 +50,8 @@ class PLMBOSampler(optunahub.load_module("samplers/simple").SimpleSampler):  # t
         trial: FrozenTrial,
         search_space: dict[str, BaseDistribution],
     ) -> dict[str, Any]:
+        if search_space == {}:
+            return {}
         if self.obj_dim is None:
             self.obj_dim = len(study.directions)
         if self.pc is None:
@@ -106,17 +108,6 @@ class PLMBOSampler(optunahub.load_module("samplers/simple").SimpleSampler):  # t
 
         print(params)
         return params
-
-    def sample_independent(
-        self,
-        study: Study,
-        trial: FrozenTrial,
-        param_name: str,
-        param_distribution: BaseDistribution,
-    ) -> Any:
-        return self._independent_sampler.sample_independent(
-            study, trial, param_name, param_distribution
-        )
 
     def __add_comparison(self):
         y_rnd_1 = np.random.rand(self.obj_dim)

--- a/package/samplers/plmbo/plmbo.py
+++ b/package/samplers/plmbo/plmbo.py
@@ -50,8 +50,6 @@ class PLMBOSampler(optunahub.load_module("samplers/simple").SimpleBaseSampler): 
         trial: FrozenTrial,
         search_space: dict[str, BaseDistribution],
     ) -> dict[str, Any]:
-        if search_space == {}:
-            return {}
         if self.obj_dim is None:
             self.obj_dim = len(study.directions)
         if self.pc is None:

--- a/package/samplers/simple/README.md
+++ b/package/samplers/simple/README.md
@@ -8,12 +8,12 @@ license: 'MIT License'
 ---
 
 ## Class or Function Names
-- SimpleSampler
+- SimpleBaseSampler
 
 ## Example
 ```python
 class UserDefinedSampler(
-    optunahub.load_module("samplers/simple").SimpleSampler
+    optunahub.load_module("samplers/simple").SimpleBaseSampler
 ):
     ...
 ```
@@ -21,4 +21,4 @@ See [`example.py`](https://github.com/optuna/optunahub-registry/blob/main/packag
 
 ## Others
 This package provides an easy sampler base class to implement custom samplers.
-You can make your own sampler easily by inheriting `SimpleSampler` and by implementing necessary methods.
+You can make your own sampler easily by inheriting `SimpleBaseSampler` and by implementing necessary methods.

--- a/package/samplers/simple/__init__.py
+++ b/package/samplers/simple/__init__.py
@@ -6,12 +6,15 @@ from typing import Any
 from optuna import Study
 from optuna.distributions import BaseDistribution
 from optuna.samplers import BaseSampler
+from optuna.samplers import RandomSampler
+from optuna.search_space import IntersectionSearchSpace
 from optuna.trial import FrozenTrial
 
 
-class SimpleSampler(BaseSampler, abc.ABC):
-    def __init__(self, search_space: dict[str, BaseDistribution]):
+class SimpleBaseSampler(BaseSampler, abc.ABC):
+    def __init__(self, search_space: dict[str, BaseDistribution] | None = None) -> None:
         self.search_space = search_space
+        self._init_defaults()
 
     def infer_relative_search_space(
         self,
@@ -21,7 +24,9 @@ class SimpleSampler(BaseSampler, abc.ABC):
         # This method is optional.
         # If you want to optimize the function with the eager search space,
         # please implement this method.
-        return self.search_space
+        if self.search_space is not None:
+            return self.search_space
+        return self._default_infer_relative_search_space(study, trial)
 
     @abc.abstractmethod
     def sample_relative(
@@ -42,6 +47,37 @@ class SimpleSampler(BaseSampler, abc.ABC):
         param_distribution: BaseDistribution,
     ) -> Any:
         # This method is optional.
-        # If you want to treat the parameters which are not include in the relative search space,
-        # please implement this method.
-        raise NotImplementedError
+        # By default, parameter values are sampled by ``optuna.samplers.RandomSampler``.
+        raise self._default_sample_independent(study, trial, param_name, param_distribution)
+
+    def _init_defaults(self) -> None:
+        self._intersection_search_space = IntersectionSearchSpace()
+        self._random_sampler = RandomSampler()
+
+    def _default_infer_relative_search_space(
+        self, study: Study, trial: FrozenTrial
+    ) -> dict[str, BaseDistribution]:
+        search_space: dict[str, BaseDistribution] = {}
+        for name, distribution in self._intersection_search_space.calculate(study).items():
+            if distribution.single():
+                # Single value objects are not sampled with the `sample_relative` method,
+                # but with the `sample_independent` method.
+                continue
+            search_space[name] = distribution
+        return search_space
+
+    def _default_sample_independent(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        param_name: str,
+        param_distribution: BaseDistribution,
+    ) -> Any:
+        # Following parameters are randomly sampled here.
+        # 1. A parameter in the initial population/first generation.
+        # 2. A parameter to mutate.
+        # 3. A parameter excluded from the intersection search space.
+
+        return self._random_sampler.sample_independent(
+            study, trial, param_name, param_distribution
+        )

--- a/package/samplers/simple/__init__.py
+++ b/package/samplers/simple/__init__.py
@@ -48,7 +48,7 @@ class SimpleBaseSampler(BaseSampler, abc.ABC):
     ) -> Any:
         # This method is optional.
         # By default, parameter values are sampled by ``optuna.samplers.RandomSampler``.
-        raise self._default_sample_independent(study, trial, param_name, param_distribution)
+        return self._default_sample_independent(study, trial, param_name, param_distribution)
 
     def _init_defaults(self) -> None:
         self._intersection_search_space = IntersectionSearchSpace()

--- a/package/samplers/simple/__init__.py
+++ b/package/samplers/simple/__init__.py
@@ -81,3 +81,7 @@ class SimpleBaseSampler(BaseSampler, abc.ABC):
         return self._random_sampler.sample_independent(
             study, trial, param_name, param_distribution
         )
+
+
+class SimpleSampler(SimpleBaseSampler):
+    pass

--- a/package/samplers/simple/example.py
+++ b/package/samplers/simple/example.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np
@@ -10,8 +12,8 @@ from optuna.trial import FrozenTrial
 import optunahub
 
 
-class UserDefinedSampler(optunahub.load_module("samplers/simple").SimpleSampler):  # type: ignore
-    def __init__(self, search_space: dict[str, BaseDistribution]) -> None:
+class UserDefinedSampler(optunahub.load_module("samplers/simple").SimpleBaseSampler):  # type: ignore
+    def __init__(self, search_space: dict[str, BaseDistribution] | None = None) -> None:
         super().__init__(search_space)
         self._rng = np.random.RandomState()
 

--- a/package/samplers/whale_optimization/whale_optimization.py
+++ b/package/samplers/whale_optimization/whale_optimization.py
@@ -13,9 +13,9 @@ SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
 class WhaleOptimizationSampler(SimpleBaseSampler):  # type: ignore
     def __init__(
         self,
+        search_space: dict[str, optuna.distributions.BaseDistribution] | None = None,
         population_size: int = 10,
         max_iter: int = 40,
-        search_space: dict[str, optuna.distributions.BaseDistribution] | None = None,
     ) -> None:
         super().__init__(search_space)
         self._rng = np.random.RandomState()

--- a/recipes/001_first.py
+++ b/recipes/001_first.py
@@ -113,6 +113,6 @@ print(f"Found x: {found_x}, (x - 2)^2: {(found_x - 2) ** 2}")
 ###################################################################################################
 # In the above examples, search space is estimated at the first trial and updated dynamically through optimization.
 # If you pass the search space to the sampler, you can avoid the overhead of estimating the search space.
-sampler = MySampler({"x": optuna.distributioins.FloatDictribution(-10, 10)})
+sampler = MySampler({"x": optuna.distributions.FloatDictribution(-10, 10)})
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=100)

--- a/recipes/001_first.py
+++ b/recipes/001_first.py
@@ -15,9 +15,9 @@ If you want to implement algorithms other than a sampler, please refer to the ot
 
 Usually, Optuna provides `BaseSampler` class to implement your own sampler.
 However, it is a bit complicated to implement a sampler from scratch.
-Instead, in OptunaHub, you can use `samplers/simple/SimpleSampler` class, which is a sampler template that can be easily extended.
+Instead, in OptunaHub, you can use `samplers/simple/SimpleBaseSampler` class, which is a sampler template that can be easily extended.
 
-You need to install `optuna` to implement your own sampler, and `optunahub` to use the template `SimpleSampler`.
+You need to install `optuna` to implement your own sampler, and `optunahub` to use the template `SimpleBaseSampler`.
 
 .. code-block:: bash
 
@@ -37,18 +37,21 @@ import optunahub
 
 
 ###################################################################################################
-# Next, define your own sampler class by inheriting `SimpleSampler` class.
+# Next, define your own sampler class by inheriting `SimpleBaseSampler` class.
 # In this example, we implement a sampler that returns a random value.
-# `SimpleSampler` class can be loaded using `optunahub.load_module` function.
+# `SimpleBaseSampler` class can be loaded using `optunahub.load_module` function.
 # `force_reload=True` argument forces downloading the sampler from the registry.
 # If we set `force_reload` to `False`, we use the cached data in our local storage if available.
 
-SimpleSampler = optunahub.load_module("samplers/simple").SimpleSampler
+SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
 
 
-class MySampler(SimpleSampler):  # type: ignore
-    # `search_space` argument is necessary for the concrete implementation of `SimpleSampler` class.
-    def __init__(self, search_space: dict[str, optuna.distributions.BaseDistribution]) -> None:
+class MySampler(SimpleBaseSampler):  # type: ignore
+    # By default, search will be estimated automatically like Optuna's built-in samplers.
+    # You can fix the search spacd by `search_space` argument of `SimpleBaseSampler` class.
+    def __init__(
+        self, search_space: dict[str, optuna.distributions.BaseDistribution] | None = None
+    ) -> None:
         super().__init__(search_space)
         self._rng = np.random.RandomState()
 
@@ -64,7 +67,11 @@ class MySampler(SimpleSampler):  # type: ignore
         search_space: dict[str, optuna.distributions.BaseDistribution],
     ) -> dict[str, Any]:
         # `search_space` argument must be identical to `search_space` argument input to `__init__` method.
-        # This method is automatically invoked by Optuna and `SimpleSampler`.
+        # This method is automatically invoked by Optuna and `SimpleBaseSampler`.
+
+        # If search space is empty, all parameter values are sampled randomly by SimpleBaseSampler.
+        if search_space == {}:
+            return {}
 
         params = {}  # type: dict[str, Any]
         for n, d in search_space.items():
@@ -91,7 +98,7 @@ def objective(trial: optuna.trial.Trial) -> float:
 ###################################################################################################
 # This sampler can be used in the same way as other Optuna samplers.
 # In the following example, we create a study and optimize it using `MySampler` class.
-sampler = MySampler({"x": optuna.distributions.FloatDistribution(-10, 10)})
+sampler = MySampler()
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=100)
 
@@ -107,3 +114,11 @@ print(f"Found x: {found_x}, (x - 2)^2: {(found_x - 2) ** 2}")
 #
 # In the next recipe, we will show how to register your sampler to OptunaHub.
 # Let's move on to :doc:`002_registration`.
+
+
+###################################################################################################
+# In the above examples, search space is estimated at the first trial and updated dynamically through optimization.
+# If you pass the search space to the sampler, you can avoid the overhead of estimating the search space.
+sampler = MySampler({"x": optuna.distributioins.FloatDictribution(-10, 10)})
+study = optuna.create_study(sampler=sampler)
+study.optimize(objective, n_trials=100)

--- a/recipes/001_first.py
+++ b/recipes/001_first.py
@@ -43,15 +43,13 @@ import optunahub
 # `force_reload=True` argument forces downloading the sampler from the registry.
 # If we set `force_reload` to `False`, we use the cached data in our local storage if available.
 
-SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
+SimpleSampler = optunahub.load_module("samplers/simple").SimpleSampler
 
 
-class MySampler(SimpleBaseSampler):  # type: ignore
+class MySampler(SimpleSampler):  # type: ignore
     # By default, search space will be estimated automatically like Optuna's built-in samplers.
-    # You can fix the search spacd by `search_space` argument of `SimpleBaseSampler` class.
-    def __init__(
-        self, search_space: dict[str, optuna.distributions.BaseDistribution] | None = None
-    ) -> None:
+    # You can fix the search spacd by `search_space` argument of `SimpleSampler` class.
+    def __init__(self, search_space: dict[str, optuna.distributions.BaseDistribution]) -> None:
         super().__init__(search_space)
         self._rng = np.random.RandomState()
 
@@ -68,10 +66,6 @@ class MySampler(SimpleBaseSampler):  # type: ignore
     ) -> dict[str, Any]:
         # `search_space` argument must be identical to `search_space` argument input to `__init__` method.
         # This method is automatically invoked by Optuna and `SimpleBaseSampler`.
-
-        # If search space is empty, all parameter values are sampled randomly by SimpleBaseSampler.
-        if search_space == {}:
-            return {}
 
         params = {}  # type: dict[str, Any]
         for n, d in search_space.items():
@@ -98,7 +92,7 @@ def objective(trial: optuna.trial.Trial) -> float:
 ###################################################################################################
 # This sampler can be used in the same way as other Optuna samplers.
 # In the following example, we create a study and optimize it using `MySampler` class.
-sampler = MySampler()
+sampler = MySampler({"x": optuna.distributions.FloatDistribution(-10, 10)})
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=100)
 

--- a/recipes/001_first.py
+++ b/recipes/001_first.py
@@ -47,7 +47,7 @@ SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
 
 
 class MySampler(SimpleBaseSampler):  # type: ignore
-    # By default, search will be estimated automatically like Optuna's built-in samplers.
+    # By default, search space will be estimated automatically like Optuna's built-in samplers.
     # You can fix the search spacd by `search_space` argument of `SimpleBaseSampler` class.
     def __init__(
         self, search_space: dict[str, optuna.distributions.BaseDistribution] | None = None

--- a/recipes/001_first.py
+++ b/recipes/001_first.py
@@ -113,6 +113,6 @@ print(f"Found x: {found_x}, (x - 2)^2: {(found_x - 2) ** 2}")
 ###################################################################################################
 # In the above examples, search space is estimated at the first trial and updated dynamically through optimization.
 # If you pass the search space to the sampler, you can avoid the overhead of estimating the search space.
-sampler = MySampler({"x": optuna.distributions.FloatDictribution(-10, 10)})
+sampler = MySampler({"x": optuna.distributions.FloatDistribution(-10, 10)})
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=100)


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

## Motivation

Currently, `SimpleSampler` does not provide Pythonic search space support (a.k.a., define-by-run), but it is one of Optuna's key features (See https://optuna.org).
This PR tries to add support for Pythonic search space while keeping the simplicity of the current `SimpleSampler`.
Additionally, it renames `SimpleSampler` to `SimpleBaseSampler` to clarify that it is an abstract class.

## Description of the changes

- Accept `search_space=None` in `SimpleSampler.__init__`. In this case, search space is estimated like Optuna's built-in samplers
- Add a default implementation of infer search space with `IntersectionSearchSpace`
- Add a default implementation of independent sampling with `RandomSampler`
- Update existing user-defined samplers
