### PR TITLE
Fix pre-trained model URL in PFNs4BO sampler

### DIFF
--- a/package/samplers/pfns4bo/README.md
+++ b/package/samplers/pfns4bo/README.md
@@ -51,12 +51,12 @@ The benchmark consists of 70 problems. The 8 problems are from HPO tabular bench
 
 ## Others
 
-The default prior argument is ``"hebo"``. This trains the PFNs model in the init of the sampler. If you want to use a pre-trained model, you can download the model checkpoint from the following link: https://github.com/automl/PFNs/blob/main/models_diff/prior_diff_real_checkpoint_n_0_epoch_42.cpkt and load it using the following code:
+The default prior argument is ``"hebo"``. This trains the PFNs model in the init of the sampler. If you want to use a pre-trained model, you can download the model checkpoint from the following link: https://github.com/automl/PFNs4BO/tree/main/pfns4bo/final_models and load it using the following code:
 
 ```python
 import torch
 
-model = torch.load("PATH/TO/prior_diff_real_checkpoint_n_0_epoch_42.cpkt")
+model = torch.load("PATH/TO/MODEL.pt")
 sampler = PFNs4BOSampler(prior=model)
 ```
 

--- a/package/samplers/pfns4bo/sampler.py
+++ b/package/samplers/pfns4bo/sampler.py
@@ -148,13 +148,13 @@ class PFNs4BOSampler(BaseSampler):
         The default prior argument is ``"hebo"``. This trains the PFNs model in the
         init of the sampler. If you want to use a pre-trained model, you can download
         the model checkpoint from the following link:
-        https://github.com/automl/PFNs/blob/main/models_diff/prior_diff_real_checkpoint_n_0_epoch_42.cpkt
+        https://github.com/automl/PFNs4BO/tree/main/pfns4bo/final_models
         and load it using the following code:
 
         .. code-block:: python
             import torch
 
-            model = torch.load("PATH/TO/prior_diff_real_checkpoint_n_0_epoch_42.cpkt")
+            model = torch.load("PATH/TO/MODEL.pt")
             sampler = PFNs4BOSampler(prior=model)
 
     .. note::


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

## Motivation
<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
As Samuel suggested in https://github.com/optuna/optunahub-registry/pull/82#discussion_r1661933819, the URL of the pre-trained PFNs model path should be fixed.

## Description of the changes
<!-- Describe the changes in this PR. -->
Fix pre-trained model URL in PFNs4BO sampler