### PR TITLE
Introduce and apply mdformat

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,12 @@
 
 Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.
 
-- [ ] I agree to the contributor agreements.
+- \[ \] I agree to the contributor agreements.
 
 ## Motivation
+
 <!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
 
 ## Description of the changes
+
 <!-- Describe the changes in this PR. -->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,9 @@ repos:
       additional_dependencies: [
         "types-PyYAML",
       ]
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.16
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-frontmatter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,16 +41,15 @@ Finally, read [`contributor agreements`](#contributor-agreements) and if you agr
 
 You can find tutorials to implement a package for the OptunaHub registry in [the OptunaHub registry documentation](https://optuna.github.io/optunahub-registry/).
 
-
 ## Contributor Agreements
 
 1. By making a contribution to this project, I certify that:
-(a) The contribution was created in whole or in part by me and I have the right to submit it under the MIT license indicated in the file:
-(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open-source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the MIT license, as indicated in the file; or
-(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+   (a) The contribution was created in whole or in part by me and I have the right to submit it under the MIT license indicated in the file:
+   (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open-source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the MIT license, as indicated in the file; or
+   (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
 
-2. By making a contribution to this project, I agree that the MIT license applies to the contribution and the contribution is used by Preferred Networks (“PFN”) or third party under the MIT license.
+1. By making a contribution to this project, I agree that the MIT license applies to the contribution and the contribution is used by Preferred Networks (“PFN”) or third party under the MIT license.
 
-3. I agree that PFN may remove my contribution from the Optuna Hub at any time, if the Contribution likely violates any of applicable law and regulation, or likely infringe or misappropriate any rights of any person or entity. I ALSO AGREE THAT PFN SHALL NOT BE RESPONSIBLE OR LIABLE FOR SUCH REMOVAL OF MY CONTRIBUTION.
+1. I agree that PFN may remove my contribution from the Optuna Hub at any time, if the Contribution likely violates any of applicable law and regulation, or likely infringe or misappropriate any rights of any person or entity. I ALSO AGREE THAT PFN SHALL NOT BE RESPONSIBLE OR LIABLE FOR SUCH REMOVAL OF MY CONTRIBUTION.
 
-4. I AGREE THAT PFN SHALL NOT BE RESPONSIBLE OR LIABLE FOR USE MODIFICATION OR REMOVAL OF MY CONTRIBUTION BY THIRD PARTY.
+1. I AGREE THAT PFN SHALL NOT BE RESPONSIBLE OR LIABLE FOR USE MODIFICATION OR REMOVAL OF MY CONTRIBUTION BY THIRD PARTY.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-
-OptunaHub Registry
-==================
+# OptunaHub Registry
 
 OptunaHub Registry is a registry service for sharing and discovering user-defined Optuna packages. It provides a platform for users to share their Optuna packages with others and discover useful packages created by other users.
 

--- a/optunahub-registry/header_confirm.py
+++ b/optunahub-registry/header_confirm.py
@@ -6,33 +6,11 @@ import frontmatter
 def header_confirm(path: str) -> None:
     post = frontmatter.load(path)
     assert "author" in post.keys(), f"author is not found in {path}"
-    assert isinstance(post["author"], str), f"author is not a string in {path}"
     assert "title" in post.keys(), f"title is not found in {path}"
-    assert isinstance(post["title"], str), f"title is not a string in {path}"
     assert "description" in post.keys(), f"description is not found in {path}"
-    assert isinstance(post["description"], str), f"description is not a string in {path}"
-    assert isinstance(post["tags"], list), f"tags is not a list in {path}"
-    assert all(
-        isinstance(v, str) for v in post["tags"]
-    ), f"tags is not a list of strings in {path}"
-    split_path = path.split("/")
-    if split_path[0] == "package":
-        category = split_path[1]
-        if category == "samplers":
-            assert "sampler" in post["tags"], f"sampler tag must be in {path}"
-        elif category == "visualizations":
-            assert "visualization" in post["tags"], f"visualization tag must be in {path}"
-        elif category == "pruners":
-            assert "pruner" in post["tags"], f"pruner tag must be in {path}"
     assert "tags" in post.keys(), f"tags is not found in {path}"
     assert "optuna_versions" in post.keys(), f"optuna_versions is not found in {path}"
-    assert isinstance(post["optuna_versions"], list), f"optuna_versions is not a list in {path}"
-    assert all(
-        isinstance(v, str) for v in post["optuna_versions"]
-    ), f"optuna_versions is not a list of strings in {path}"
     assert "license" in post.keys(), f"license is not found in {path}"
-    assert isinstance(post["license"], str), f"license is not a string in {path}"
-    assert post["license"] == "MIT License", f"license must be 'MIT License' in {path}"
 
 
 if __name__ == "__main__":

--- a/optunahub-registry/header_confirm.py
+++ b/optunahub-registry/header_confirm.py
@@ -6,11 +6,24 @@ import frontmatter
 def header_confirm(path: str) -> None:
     post = frontmatter.load(path)
     assert "author" in post.keys(), f"author is not found in {path}"
+    assert isinstance(post["author"], str), f"author is not a string in {path}"
     assert "title" in post.keys(), f"title is not found in {path}"
+    assert isinstance(post["title"], str), f"title is not a string in {path}"
     assert "description" in post.keys(), f"description is not found in {path}"
+    assert isinstance(post["description"], str), f"description is not a string in {path}"
     assert "tags" in post.keys(), f"tags is not found in {path}"
+    assert isinstance(post["tags"], list), f"tags is not a list in {path}"
+    assert all(
+        isinstance(v, str) for v in post["tags"]
+    ), f"tags is not a list of strings in {path}"
     assert "optuna_versions" in post.keys(), f"optuna_versions is not found in {path}"
+    assert isinstance(post["optuna_versions"], list), f"optuna_versions is not a list in {path}"
+    assert all(
+        isinstance(v, str) for v in post["optuna_versions"]
+    ), f"optuna_versions is not a list of strings in {path}"
     assert "license" in post.keys(), f"license is not found in {path}"
+    assert isinstance(post["license"], str), f"license is not a string in {path}"
+    assert post["license"] == "MIT License", f"license must be 'MIT License' in {path}"
 
 
 if __name__ == "__main__":

--- a/optunahub-registry/header_confirm.py
+++ b/optunahub-registry/header_confirm.py
@@ -11,11 +11,20 @@ def header_confirm(path: str) -> None:
     assert isinstance(post["title"], str), f"title is not a string in {path}"
     assert "description" in post.keys(), f"description is not found in {path}"
     assert isinstance(post["description"], str), f"description is not a string in {path}"
-    assert "tags" in post.keys(), f"tags is not found in {path}"
     assert isinstance(post["tags"], list), f"tags is not a list in {path}"
     assert all(
         isinstance(v, str) for v in post["tags"]
     ), f"tags is not a list of strings in {path}"
+    split_path = path.split("/")
+    if split_path[0] == "package":
+        category = split_path[1]
+        if category == "samplers":
+            assert "sampler" in post["tags"], f"sampler tag must be in {path}"
+        elif category == "visualizations":
+            assert "visualization" in post["tags"], f"visualization tag must be in {path}"
+        elif category == "pruners":
+            assert "pruner" in post["tags"], f"pruner tag must be in {path}"
+    assert "tags" in post.keys(), f"tags is not found in {path}"
     assert "optuna_versions" in post.keys(), f"optuna_versions is not found in {path}"
     assert isinstance(post["optuna_versions"], list), f"optuna_versions is not a list in {path}"
     assert all(

--- a/package/pruners/median/README.md
+++ b/package/pruners/median/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Median Pruner'
-description: 'Pruner using the median stopping rule.'
-tags: ['pruner', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Median Pruner
+description: Pruner using the median stopping rule.
+tags: [pruner, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - MedianPruner
 
 ## Example
+
 ```python
 import optuna
 from optuna.pruners import MedianPruner
@@ -33,5 +35,5 @@ study.optimize(objective, n_trials=20)
 ```
 
 ## Others
-See the [documentation](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.MedianPruner.html) for more details.
 
+See the [documentation](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.MedianPruner.html) for more details.

--- a/package/pruners/percentile/README.md
+++ b/package/pruners/percentile/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Percentile Pruner'
-description: 'Pruner to keep the specified percentile of the trials.'
-tags: ['pruner', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Percentile Pruner
+description: Pruner to keep the specified percentile of the trials.
+tags: [pruner, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - PercentilePruner
 
 ## Example
+
 ```python
 import optuna
 from optuna.pruners import PercentilePruner
@@ -33,5 +35,5 @@ study.optimize(objective, n_trials=20)
 ```
 
 ## Others
-See the [documentation](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.PercentilePruner.html) for more details.
 
+See the [documentation](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.PercentilePruner.html) for more details.

--- a/package/samplers/botorch_sampler/README.md
+++ b/package/samplers/botorch_sampler/README.md
@@ -1,26 +1,29 @@
 ---
-author: 'Optuna team'
-title: 'BoTorch Sampler'
-description: 'A Sampler using botorch library as the backend.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: BoTorch Sampler
+description: A Sampler using botorch library as the backend.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - BoTorchSampler
 
 ## Installation
+
 ```bash
 pip install optuna-integration botorch
 ```
 
 ## Example
+
 ```python
 from optuna_integration import BoTorchSampler
 sampler = BoTorchSampler()
 ```
 
 ## Others
-See the [documentation](https://optuna-integration.readthedocs.io/en/latest/reference/generated/optuna_integration.BoTorchSampler.html) for more details.
 
+See the [documentation](https://optuna-integration.readthedocs.io/en/latest/reference/generated/optuna_integration.BoTorchSampler.html) for more details.

--- a/package/samplers/brute_force/README.md
+++ b/package/samplers/brute_force/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Brute Force Search'
-description: 'Sampler using brute force.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Brute Force Search
+description: Sampler using brute force.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - BruteForceSampler
 
 ## Example
+
 ```python
 import optuna
 from optuna.samplers import BruteForceSampler
@@ -27,5 +29,5 @@ study.optimize(objective, n_trials=10)
 ```
 
 ## Others
-See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.BruteForceSampler.html) for more details.
 
+See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.BruteForceSampler.html) for more details.

--- a/package/samplers/cmaes/README.md
+++ b/package/samplers/cmaes/README.md
@@ -1,21 +1,24 @@
 ---
-author: 'Optuna team'
-title: 'CMA-ES Sampler'
-description: 'A sampler using cmaes as the backend.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: CMA-ES Sampler
+description: A sampler using cmaes as the backend.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - CmaEsSampler
 
 ## Installation
+
 ```bash
 pip install cmaes
 ```
 
 ## Example
+
 ```python
 import optuna
 from optuna.samplers import CmaEsSampler
@@ -33,4 +36,5 @@ study.optimize(objective, n_trials=20)
 ```
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.CmaEsSampler.html) for more details.

--- a/package/samplers/demo/README.md
+++ b/package/samplers/demo/README.md
@@ -1,18 +1,21 @@
 ---
-author: 'Optuna team'
-title: 'Demo Sampler'
-description: 'Demo Sampler of OptunaHub'
-tags: ['sampler']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Demo Sampler
+description: Demo Sampler of OptunaHub
+tags: [sampler]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - DemoSampler
 
 ## Example
+
 ```python
 module = optunahub.load_module("samplers/demo")
 sampler = module.DemoSampler(seed=42)
 ```
+
 See [`example.py`](https://github.com/optuna/optunahub-registry/blob/main/package/samplers/demo/example.py) for more details.

--- a/package/samplers/evo_merge/README.md
+++ b/package/samplers/evo_merge/README.md
@@ -1,17 +1,19 @@
 ---
-author: 'Optuna team'
-title: 'Evolutionary LLM Merge Sampler'
-description: 'A sampler for evolutionary LLM merge.'
-tags: ['sampler', 'LLM']
+author: Optuna team
+title: Evolutionary LLM Merge Sampler
+description: A sampler for evolutionary LLM merge.
+tags: [sampler, LLM]
 optuna_versions: [3.6.1]
-license: 'MIT License'
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - EvoMergeSampler
 - EvoMergeTrial
 
 ## Installation
+
 ```bash
 pip install git+https://github.com/arcee-ai/mergekit.git
 pip install sentencepiece accelerate protobuf bitsandbytes langchain langchain-community datasets
@@ -20,6 +22,7 @@ export HF_TOKEN=xxx
 ```
 
 ## Example
+
 ```python
 sampler = EvoMergeSampler(base_config="path/to/config/yml/file")
 study = optuna.create_study(sampler=sampler)
@@ -35,6 +38,7 @@ for _ in range(100):
 
 print(study.trials_dataframe(attrs=("number", "value")))
 ```
+
 See [`example.py`](https://github.com/optuna/optunahub-registry/blob/main/package/samplers/evo_merge/example.py) for a full example. You need GPU with 16G VLAM to run this example.
 The following figures are obtained from the analysis of the optimization.
 ![History Plot](images/history.png "History Plot")
@@ -43,4 +47,5 @@ The following figures are obtained from the analysis of the optimization.
 ## Others
 
 ### Reference
+
 Akiba, T., Shing, M., Tang, Y., Sun, Q., & Ha, D. (2024). Evolutionary Optimization of Model Merging Recipes. arXiv preprint arXiv:2403.13187.

--- a/package/samplers/gp/README.md
+++ b/package/samplers/gp/README.md
@@ -1,21 +1,24 @@
 ---
-author: 'Optuna team'
-title: 'Gaussian Process-Based Sampler'
-description: 'Sampler using Gaussian process-based Bayesian optimization.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Gaussian Process-Based Sampler
+description: Sampler using Gaussian process-based Bayesian optimization.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - GPSampler
 
 ## Installation
+
 ```bash
 pip install scipy pytorch
 ```
 
 ## Example
+
 ```python
 import optuna
 from optuna.samplers import GPSampler
@@ -32,4 +35,5 @@ study.optimize(objective, n_trials=100)
 ```
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.GPSampler.html) for more details.

--- a/package/samplers/grid_search/README.md
+++ b/package/samplers/grid_search/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Grid Search'
-description: 'Sampler using grid search.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Grid Search
+description: Sampler using grid search.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - GridSampler
 
 ## Example
+
 ```python
 import optuna
 from optuna.samplers import GridSampler
@@ -29,4 +31,5 @@ study.optimize(objective)
 ```
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.GridSampler.html) for more details.

--- a/package/samplers/hebo/README.md
+++ b/package/samplers/hebo/README.md
@@ -2,15 +2,17 @@
 author: HideakiImamura
 title: HEBO (Heteroscedastic and Evolutionary Bayesian Optimisation)
 description: HEBO addresses the problem of noisy and heterogeneous objective functions by using a heteroscedastic Gaussian process and an evolutionary algorithm.
-tags: ["sampler", "Bayesian optimization", "Heteroscedastic Gaussian process", "Evolutionary algorithm"]
-optuna_versions: ["3.6.1"]
-license: "MIT License" 
+tags: [sampler, Bayesian optimization, Heteroscedastic Gaussian process, Evolutionary algorithm]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - HEBOSampler
 
 ## Installation
+
 ```bash
 pip install -r requirements.txt
 git clone git@github.com:huawei-noah/HEBO.git
@@ -19,6 +21,7 @@ pip install -e .
 ```
 
 ## Example
+
 ```python
 search_space = {
     "x": FloatDistribution(-10, 10),
@@ -28,13 +31,13 @@ search_space = {
 sampler = HEBOSampler(search_space)
 study = optuna.create_study(sampler=sampler)
 ```
+
 See [`example.py`](https://github.com/optuna/optunahub-registry/blob/main/package/samplers/hebo/example.py) for a full example.
 ![History Plot](images/hebo_optimization_history.png "History Plot")
 
-
 ## Others
 
-HEBO is the winning submission to the [NeurIPS 2020 Black-Box Optimisation Challenge](https://bbochallenge.com/leaderboard). 
+HEBO is the winning submission to the [NeurIPS 2020 Black-Box Optimisation Challenge](https://bbochallenge.com/leaderboard).
 Please refer to [the official repository of HEBO](https://github.com/huawei-noah/HEBO/tree/master/HEBO) for more details.
 
 ### Reference

--- a/package/samplers/implicit_natural_gradient/README.md
+++ b/package/samplers/implicit_natural_gradient/README.md
@@ -1,23 +1,27 @@
 ---
-author: 'Yuhei Otomo and Masashi Shibata'
-title: 'Implicit Natural Gradient Sampler'
-description: 'A sampler based on Implicit Natural Gradient.'
-tags: ['sampler']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Yuhei Otomo and Masashi Shibata
+title: Implicit Natural Gradient Sampler
+description: A sampler based on Implicit Natural Gradient.
+tags: [sampler]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - ImplicitNaturalGradientSampler
 
 ## Example
+
 ```python
 mod = optunahub.load_module("samplers/implicit_natural_gradient")
 sampler = mod.ImplicitNaturalGradientSampler()
 ```
+
 See [`example.py`](https://github.com/optuna/optunahub-registry/blob/main/package/samplers/implicit_natural_gradient/example.py) for more details.
 
 ## Others
 
 ### Reference
+
 Yueming Lyu, Ivor W. Tsang (2019). Black-box Optimizer with Implicit Natural Gradient. arXiv:1910.04301

--- a/package/samplers/nsgaii/README.md
+++ b/package/samplers/nsgaii/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'NSGAII Search'
-description: 'Sampler using NSGAII algotithm.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: NSGAII Search
+description: Sampler using NSGAII algotithm.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - NSGAIISampler
 
 ## Example
+
 ```python
 import optuna
 from optuna.samplers import NSGAIISampler
@@ -27,5 +29,5 @@ study.optimize(objective, n_trials=10)
 ```
 
 ## Others
-See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.NSGAIISampler.html) for more details.
 
+See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.NSGAIISampler.html) for more details.

--- a/package/samplers/nsgaiii/README.md
+++ b/package/samplers/nsgaiii/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'NSGAIII Search'
-description: 'Sampler using NSGAIII algotithm.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: NSGAIII Search
+description: Sampler using NSGAIII algotithm.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - NSGAIIISampler
 
 ## Example
+
 ```python
 import optuna
 from optuna.samplers import NSGAIIISampler
@@ -27,5 +29,5 @@ study.optimize(objective, n_trials=10)
 ```
 
 ## Others
-See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.NSGAIIISampler.html) for more details.
 
+See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.NSGAIIISampler.html) for more details.

--- a/package/samplers/partial_fixed/README.md
+++ b/package/samplers/partial_fixed/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Partial Fixed Sampler'
-description: 'Sampler with partially fixed parameters.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Partial Fixed Sampler
+description: Sampler with partially fixed parameters.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - PartialFixedSampler
 
 ## Example
+
 ```python
 import optuna
 from optuna.samplers import PartialFixedSampler
@@ -31,4 +33,5 @@ study.optimize(objective, n_trials=10)
 ```
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.PartialFixedSampler.html) for more details.

--- a/package/samplers/pfns4bo/README.md
+++ b/package/samplers/pfns4bo/README.md
@@ -1,21 +1,24 @@
 ---
-author: "Hideaki Imamura"
-title: "PFNs4BO sampler"
-description: "In-context learning for Bayesian optimization. This sampler uses Prior-data Fitted Networks (PFNs) as a surrogate model for Bayesian optimization."
-tags: ["sampler", "Bayesian optimization", "Pre-trained Model"]
-optuna_versions: ["3.6.1"]
-license: "MIT License"
+author: Hideaki Imamura
+title: PFNs4BO sampler
+description: In-context learning for Bayesian optimization. This sampler uses Prior-data Fitted Networks (PFNs) as a surrogate model for Bayesian optimization.
+tags: [sampler, Bayesian optimization, Pre-trained Model]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - PFNs4BOSampler
 
 ## Installation
+
 ```bash
 pip install -r requirements.txt
 ```
 
 ## Example
+
 ```python
 from __future__ import annotations
 
@@ -42,6 +45,7 @@ if __name__ == "__main__":
     print(study.best_params)
     print(study.best_value)
 ```
+
 See [`example.py`](https://github.com/optuna/optunahub-registry/blob/main/package/samplers/pfns4bo/example.py) for a full example. You need GPU to run this example.
 
 The following figures are experimental results of the comparison between PFNs4BO and the random search.
@@ -51,7 +55,7 @@ The benchmark consists of 70 problems. The 8 problems are from HPO tabular bench
 
 ## Others
 
-The default prior argument is ``"hebo"``. This trains the PFNs model in the init of the sampler. If you want to use a pre-trained model, you can download the model checkpoint from the following link: https://github.com/automl/PFNs4BO/tree/main/pfns4bo/final_models and load it using the following code:
+The default prior argument is `"hebo"`. This trains the PFNs model in the init of the sampler. If you want to use a pre-trained model, you can download the model checkpoint from the following link: https://github.com/automl/PFNs4BO/tree/main/pfns4bo/final_models and load it using the following code:
 
 ```python
 import torch
@@ -67,4 +71,6 @@ The performance of PFNs4BO with the HEBO+ prior is maximized with the number of 
 Samuel Müller, Matthias Feurer, Noah Hollmann, and Frank Hutter. 2023. PFNs4BO: in-context learning for Bayesian optimization. In Proceedings of the 40th International Conference on Machine Learning (ICML'23), Vol. 202. JMLR.org, Article 1056, 25444–25470.
 
 See the [paper](https://arxiv.org/abs/2305.17535) for more details.
+
+```
 ```

--- a/package/samplers/plmbo/README.md
+++ b/package/samplers/plmbo/README.md
@@ -1,21 +1,24 @@
 ---
-author: "Ryota Ozaki"
-title: "PLMBO (Preference Learning Multi-Objective Bayesian Optimization)"
-description: "Interatctive multi-objective Bayesian optimization based on user preference"
-tags: ["sampler", "interactive optimization", "Bayesian optimization", "multi-objective optimization", "preference learning", "active learning"]
-optuna_versions: ["3.6.1"]
-license: "MIT License"
+author: Ryota Ozaki
+title: PLMBO (Preference Learning Multi-Objective Bayesian Optimization)
+description: Interatctive multi-objective Bayesian optimization based on user preference
+tags: [sampler, interactive optimization, Bayesian optimization, multi-objective optimization, preference learning, active learning]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - PLMBOSampler
 
 ## Installation
+
 ```sh
 pip install -r https://raw.githubusercontent.com/optuna/optunahub-registry/main/package/samplers/plmbo/requirements.txt
 ```
 
 ## Example
+
 ```python
 from __future__ import annotations
 
@@ -67,10 +70,13 @@ if __name__ == "__main__":
 ```
 
 ## Others
+
 ### Reference
+
 R Ozaki, K Ishikawa, Y Kanzaki, S Takeno, I Takeuchi, and M Karasuyama. (2024). Multi-Objective Bayesian Optimization with Active Preference Learning. Proceedings of the AAAI Conference on Artificial Intelligence.
 
 ### Bibtex
+
 ```
 @inproceedings{ozaki2024multi,
   title={Multi-Objective Bayesian Optimization with Active Preference Learning},

--- a/package/samplers/pycma/README.md
+++ b/package/samplers/pycma/README.md
@@ -1,25 +1,29 @@
 ---
-author: 'Optuna team'
-title: 'PyCMA Sampler'
-description: 'A CMA-ES Sampler using cma library as the backend.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: PyCMA Sampler
+description: A CMA-ES Sampler using cma library as the backend.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - PyCmaSampler
 
 ## Installation
+
 ```bash
 pip install optuna-integration cma
 ```
 
 ## Example
+
 ```python
 from optuna_integration import PyCmaSampler
 sampler = PyCmaSampler()
 ```
 
 ## Others
+
 See the [documentation](https://optuna-integration.readthedocs.io/en/latest/reference/generated/optuna_integration.PyCmaSampler.html) for more details.

--- a/package/samplers/qmc/README.md
+++ b/package/samplers/qmc/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'QMC Search'
-description: 'Sampler using Quasi Monte Carlo sampling.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: QMC Search
+description: Sampler using Quasi Monte Carlo sampling.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - QMCSampler
 
 ## Example
+
 ```python
 import optuna
 from optuna.samplers import QMCSampler
@@ -27,5 +29,5 @@ study.optimize(objective, n_trials=10)
 ```
 
 ## Others
-See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.QMCSampler.html) for more details.
 
+See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.QMCSampler.html) for more details.

--- a/package/samplers/random_search/README.md
+++ b/package/samplers/random_search/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Random Search'
-description: 'Sampler using random sampling.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Random Search
+description: Sampler using random sampling.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - RandomSampler
 
 ## Example
+
 ```python
 import optuna
 from optuna.samplers import RandomSampler
@@ -27,5 +29,5 @@ study.optimize(objective, n_trials=10)
 ```
 
 ## Others
-See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.RandomSampler.html) for more details.
 
+See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.RandomSampler.html) for more details.

--- a/package/samplers/simple/README.md
+++ b/package/samplers/simple/README.md
@@ -3,7 +3,7 @@ author: Optuna team
 title: Simple Sampler
 description: An easy sampler base class to implement custom samplers.
 tags: [sampler, development]
-optuna_versions: ['3.6']
+optuna_versions: [3.6.1]
 license: MIT License
 ---
 

--- a/package/samplers/simple/README.md
+++ b/package/samplers/simple/README.md
@@ -1,24 +1,28 @@
 ---
-author: 'Optuna team'
-title: 'Simple Sampler'
-description: 'An easy sampler base class to implement custom samplers.'
-tags: ['sampler', 'development']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Simple Sampler
+description: An easy sampler base class to implement custom samplers.
+tags: [sampler, development]
+optuna_versions: ['3.6']
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - SimpleBaseSampler
 
 ## Example
+
 ```python
 class UserDefinedSampler(
     optunahub.load_module("samplers/simple").SimpleBaseSampler
 ):
     ...
 ```
+
 See [`example.py`](https://github.com/optuna/optunahub-registry/blob/main/package/samplers/simple/example.py) for more details.
 
 ## Others
+
 This package provides an easy sampler base class to implement custom samplers.
 You can make your own sampler easily by inheriting `SimpleBaseSampler` and by implementing necessary methods.

--- a/package/samplers/simulated_annealing/README.md
+++ b/package/samplers/simulated_annealing/README.md
@@ -1,22 +1,26 @@
 ---
-author: 'Optuna team'
-title: 'Simulated Annealing Sampler'
-description: 'Sampler based on simulated annealing algorithm.'
-tags: ['sampler', 'simulated annealing']
-optuna_versions: ['3.5.0', '3.6.0']
-license: 'MIT License'
+author: Optuna team
+title: Simulated Annealing Sampler
+description: Sampler based on simulated annealing algorithm.
+tags: [sampler, simulated annealing]
+optuna_versions: [3.5.0, 3.6.0]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - SimulatedAnnealingSampler
 
 ## Example
+
 ```python
 mod = optunahub.load_module("samplers/simulated_annealing")
 sampler = mod.SimulatedAnnealingSampler()
 ```
+
 See [`example.py`](https://github.com/optuna/optunahub-registry/blob/main/package/samplers/simulated_annealing/example.py) for more details.
 
 ## Others
+
 This package provides a sampler based on Simulated Annealing algorithm.
 For more details, see [the documentation](https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/005_user_defined_sampler.html).

--- a/package/samplers/tpe/README.md
+++ b/package/samplers/tpe/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'TPE Sampler'
-description: 'Sampler using TPE (Tree-structured Parzen Estimator) algorithm.'
-tags: ['sampler', 'built-in']
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: TPE Sampler
+description: Sampler using TPE (Tree-structured Parzen Estimator) algorithm.
+tags: [sampler, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - TPESampler
 
 ## Example
+
 ```python
 import optuna
 from optuna.samplers import TPESampler
@@ -27,4 +29,5 @@ study.optimize(objective, n_trials=10)
 ```
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.TPESampler.html) for more details.

--- a/package/samplers/whale_optimization/README.md
+++ b/package/samplers/whale_optimization/README.md
@@ -1,16 +1,18 @@
 ---
-author: "mist714"
-title: "Sampler using Whale Optimization Algorithm"
-description: "Swarm Algorithm Inspired by Pod of Whale"
-tags: ["sampler"]
-optuna_versions: ["3.6.1"]
-license: "MIT License"
+author: mist714
+title: Sampler using Whale Optimization Algorithm
+description: Swarm Algorithm Inspired by Pod of Whale
+tags: [sampler]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - WhaleOptimizationSampler
 
 ## Example
+
 ```python
 from __future__ import annotations
 
@@ -43,5 +45,7 @@ if __name__ == "__main__":
 ```
 
 ## Others
+
 ### Reference
+
 Mirjalili, Seyedali & Lewis, Andrew. (2016). The Whale Optimization Algorithm. Advances in Engineering Software. 95. 51-67. 10.1016/j.advengsoft.2016.01.008.

--- a/package/visualization/plot_contour/README.md
+++ b/package/visualization/plot_contour/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Contour Plot'
-description: 'Plot the parameter relationship as contour plot in a study.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Contour Plot
+description: Plot the parameter relationship as contour plot in a study.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_contour
 
 ## Example
+
 ```python
 from optuna.visualization import plot_contour
 plot_contour(study)
@@ -19,4 +21,5 @@ plot_contour(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_contour.html) for more details.

--- a/package/visualization/plot_edf/README.md
+++ b/package/visualization/plot_edf/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Empirical Distribution Function Plot'
-description: 'Plot the objective value EDF (empirical distribution function) of a study.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Empirical Distribution Function Plot
+description: Plot the objective value EDF (empirical distribution function) of a study.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_edf
 
 ## Example
+
 ```python
 from optuna.visualization import plot_edf
 plot_edf(study)
@@ -19,4 +21,5 @@ plot_edf(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_edf.html) for more details.

--- a/package/visualization/plot_hypervolume_history/README.md
+++ b/package/visualization/plot_hypervolume_history/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Hypervolume History Plot'
-description: 'Plot hypervolume history of all trials in a study.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Hypervolume History Plot
+description: Plot hypervolume history of all trials in a study.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_hypervolume_history
 
 ## Example
+
 ```python
 from optuna.visualization import plot_hypervolume_history
 plot_hypervolume_history(study, reference_point)
@@ -19,4 +21,5 @@ plot_hypervolume_history(study, reference_point)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_hypervolume_history.html) for more details.

--- a/package/visualization/plot_hypervolume_history_with_rp/README.md
+++ b/package/visualization/plot_hypervolume_history_with_rp/README.md
@@ -1,20 +1,23 @@
 ---
-author: 'Optuna team'
-title: 'Plot Hypervolume History with Reference Point'
-description: 'Plot hypervolume history with the reference point information.'
-tags: ['visualization', 'hypervolume', 'multi-objective optimization']
-optuna_versions: ['3.6.0']
-license: 'MIT License'
+author: Optuna team
+title: Plot Hypervolume History with Reference Point
+description: Plot hypervolume history with the reference point information.
+tags: [visualization, hypervolume, multi-objective optimization]
+optuna_versions: [3.6.0]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_hypervolume_history
 
 ## Example
+
 ```python
 mod = optunahub.load_module("visualization/plot_hypervolume_history_with_rp")
 mod.plot_hypervolume_history(study, reference_point)
 ```
+
 See [`example.py`](https://github.com/optuna/optunahub-registry/blob/main/package/visualization/plot_hypervolume_history_with_rp/example.py) for more details.
 The example of generated image is as follows.
 

--- a/package/visualization/plot_intermediate_values/README.md
+++ b/package/visualization/plot_intermediate_values/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Intermediate Values Plot'
-description: 'Plot intermediate values of all trials in a study.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Intermediate Values Plot
+description: Plot intermediate values of all trials in a study.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_intermediate_values
 
 ## Example
+
 ```python
 from optuna.visualization import plot_intermediate_values
 plot_intermediate_values(study)
@@ -19,4 +21,5 @@ plot_intermediate_values(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_intermediate_values.html) for more details.

--- a/package/visualization/plot_optimization_history/README.md
+++ b/package/visualization/plot_optimization_history/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Optimization History Plot'
-description: 'Plot optimization history of all trials in a study.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Optimization History Plot
+description: Plot optimization history of all trials in a study.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_optimization_history
 
 ## Example
+
 ```python
 from optuna.visualization import plot_optimization_history
 plot_optimization_history(study)
@@ -19,4 +21,5 @@ plot_optimization_history(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_optimization_history.html) for more details.

--- a/package/visualization/plot_parallel_coordinate/README.md
+++ b/package/visualization/plot_parallel_coordinate/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Parallel Coordinate Plot'
-description: 'Plot the high-dimensional parameter relationships in a study.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Parallel Coordinate Plot
+description: Plot the high-dimensional parameter relationships in a study.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_parallel_coordinate
 
 ## Example
+
 ```python
 from optuna.visualization import plot_parallel_coordinate
 plot_parallel_coordinate(study)
@@ -19,4 +21,5 @@ plot_parallel_coordinate(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_parallel_coordinate.html) for more details.

--- a/package/visualization/plot_param_importances/README.md
+++ b/package/visualization/plot_param_importances/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Hyperparameter Importances Plot'
-description: 'Plot hyperparameter importances.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Hyperparameter Importances Plot
+description: Plot hyperparameter importances.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_param_importances
 
 ## Example
+
 ```python
 from optuna.visualization import plot_param_importances
 plot_param_importances(study)
@@ -19,4 +21,5 @@ plot_param_importances(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_param_importances.html) for more details.

--- a/package/visualization/plot_pareto_front/README.md
+++ b/package/visualization/plot_pareto_front/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Pareto-front Plot'
-description: 'Plot the Pareto front of a study.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Pareto-front Plot
+description: Plot the Pareto front of a study.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_pareto_front
 
 ## Example
+
 ```python
 from optuna.visualization import plot_pareto_front
 plot_pareto_front(study)
@@ -19,4 +21,5 @@ plot_pareto_front(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_pareto_front.html) for more details.

--- a/package/visualization/plot_rank/README.md
+++ b/package/visualization/plot_rank/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Rank Plot'
-description: 'Plot parameter relations as scatter plots with colors indicating ranks of target value.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Rank Plot
+description: Plot parameter relations as scatter plots with colors indicating ranks of target value.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_rank
 
 ## Example
+
 ```python
 from optuna.visualization import plot_rank
 plot_rank(study)
@@ -19,4 +21,5 @@ plot_rank(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_rank.html) for more details.

--- a/package/visualization/plot_slice/README.md
+++ b/package/visualization/plot_slice/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Slice Plot'
-description: 'Plot the parameter relationship as slice plot in a study.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Slice Plot
+description: Plot the parameter relationship as slice plot in a study.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_slice
 
 ## Example
+
 ```python
 from optuna.visualization import plot_slice
 plot_slice(study)
@@ -19,4 +21,5 @@ plot_slice(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_slice.html) for more details.

--- a/package/visualization/plot_terminator_improvement/README.md
+++ b/package/visualization/plot_terminator_improvement/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Terminator Improvement Plot'
-description: 'Plot the potentials for future objective improvement.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Terminator Improvement Plot
+description: Plot the potentials for future objective improvement.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_terminator_improvement
 
 ## Example
+
 ```python
 from optuna.visualization import plot_terminator_improvement
 plot_terminator_improvement(study)
@@ -19,4 +21,5 @@ plot_terminator_improvement(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_terminator_improvement.html) for more details.

--- a/package/visualization/plot_timeline/README.md
+++ b/package/visualization/plot_timeline/README.md
@@ -1,16 +1,18 @@
 ---
-author: 'Optuna team'
-title: 'Timeline Plot'
-description: 'Plot the timeline of a study.'
-tags: ['visualization', "built-in"]
-optuna_versions: ['3.6.1']
-license: 'MIT License'
+author: Optuna team
+title: Timeline Plot
+description: Plot the timeline of a study.
+tags: [visualization, built-in]
+optuna_versions: [3.6.1]
+license: MIT License
 ---
 
 ## Class or Function Names
+
 - plot_timeline
 
 ## Example
+
 ```python
 from optuna.visualization import plot_timeline
 plot_timeline(study)
@@ -19,4 +21,5 @@ plot_timeline(study)
 ![Example](images/thumbnail.png "Example")
 
 ## Others
+
 See the [documentation](https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_timeline.html) for more details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dynamic = ["version"]
 checking = [
   "pre-commit",
   "ruff==0.3.5",
+  "mdformat",
+  "mdformat-frontmatter",
   "mypy==1.9.0",
   "types-PyYAML",
 ]

--- a/recipes/002_registration.py
+++ b/recipes/002_registration.py
@@ -63,20 +63,20 @@ Although we recommend you write proper type hints, if you find it difficult to c
   .. code-block:: markdown
 
       ---
-      author: 'Optuna team'
-      title: 'Demo Sampler'
-      description: 'Demo Sampler of OptunaHub'
-      tags: ['sampler']
-      optuna_versions: ['3.6.1']
-      license: 'MIT License'
+      author: Optuna team
+      title: Demo Sampler
+      description: Demo Sampler of OptunaHub
+      tags: [sampler]
+      optuna_versions: [3.6.1]
+      license: MIT License
       ---
 
-  - `author`: The author of the package. It can be your name or your organization name.
-  - `title`: The package title. It should not be a class/function name but a human-readable name. For example, `Demo Sampler` is a good title, but `DemoSampler` is not.
-  - `description`: A brief description of the package. It should be a one-sentence summary of the package.
-  - `tags`: The package tags. It should be a list of strings. The tags must include `sampler`, `visualization`, or `pruner` depending on the type of the package. You can add other tags as needed. For example, "['sampler', 'LLM']".
-  - `optuna_versions`: A list of Optuna versions that the package supports. It should be a list of strings. For example, "['3.5.0', '3.6.1']".
-  - `license`: The license of the package. It should be a string. For example, `'MIT License'`. The license must be `MIT License` in the current version of OptunaHub.
+  - `author` (string): The author of the package. It can be your name or your organization name.
+  - `title` (string): The package title. It should not be a class/function name but a human-readable name. For example, `Demo Sampler` is a good title, but `DemoSampler` is not.
+  - `description` (string): A brief description of the package. It should be a one-sentence summary of the package.
+  - `tags` (list[string]): The package tags. It should be a list of strings. The tags must include `sampler`, `visualization`, or `pruner` depending on the type of the package. You can add other tags as needed. For example, "['sampler', 'LLM']".
+  - `optuna_versions` (list[string]): A list of Optuna versions that the package supports. It should be a list of strings. You can find your Optuna version with `python -c 'import optuna; print(optuna.__version__)'`.
+  - `license` (string): The license of the package. It should be a string. For example, `MIT License`. The license must be `MIT License` in the current version of OptunaHub.
 
 - `Class or Function Names` section that describes the classes or functions provided by the package. If you provide multiple classes or functions, you should list them in this section. Note that the section must be a markdown list. If you provide only one class or function, you can simply write the class or function name. Note that the documentation of the classes or functions must be written in their docstrings. If you want to refer to the documentation, please leave the source code link, or write them in the following `Others` section. For example:
 

--- a/recipes/002_registration.py
+++ b/recipes/002_registration.py
@@ -74,7 +74,7 @@ Although we recommend you write proper type hints, if you find it difficult to c
   - `author`: The author of the package. It can be your name or your organization name.
   - `title`: The package title. It should not be a class/function name but a human-readable name. For example, `Demo Sampler` is a good title, but `DemoSampler` is not.
   - `description`: A brief description of the package. It should be a one-sentence summary of the package.
-  - `tags`: The package tags. It should be a list of strings. The tags must include `sampler` or `visualization` depending on the type of the package. You can add other tags as needed. For example, "['sampler', 'LLM']".
+  - `tags`: The package tags. It should be a list of strings. The tags must include `sampler`, `visualization`, or `pruner` depending on the type of the package. You can add other tags as needed. For example, "['sampler', 'LLM']".
   - `optuna_versions`: A list of Optuna versions that the package supports. It should be a list of strings. For example, "['3.5.0', '3.6.1']".
   - `license`: The license of the package. It should be a string. For example, `'MIT License'`. The license must be `MIT License` in the current version of OptunaHub.
 

--- a/template/README.md
+++ b/template/README.md
@@ -12,6 +12,11 @@ This is an example of the frontmatters.
 All columns must be string.
 You can omit quotes when value types are not ambiguous.
 However, quotes are required in ambiguous cases, e.g., '3.5' must not be 3.5.
+For tags, a package placed in
+- package/samplers/ must include the tag "sampler"
+- package/visualilzation/ must include the tag "visualization"
+- package/pruners/ must include the tag "pruner"
+respectively.
 
 ---
 author: Optuna team

--- a/template/README.md
+++ b/template/README.md
@@ -1,21 +1,24 @@
 ---
-author: "Please fill in the author name here."
-title: "Please fill in the title of the feature here."
-description: "Please fill in the description of the feature here."
-tags: ["Please fill in the list of tags here."]
-optuna_versions: ["Please fill in the list of versions of Optuna in which you have confirmed the feature works, e.g., 3.6.1."]
-license: "MIT License"
+author: Please fill in the author name here.
+title: Please fill in the title of the feature here.
+description: Please fill in the description of the feature here.
+tags: [Please fill in the list of tags here.]
+optuna_versions: ['Please fill in the list of versions of Optuna in which you have confirmed the feature works, e.g., 3.6.1.']
+license: MIT License
 ---
 
 <!--
 This is an example of the frontmatters.
+All columns must be string.
+You can omit quotes when value types are not ambiguous.
+However, quotes are required in ambiguous cases, e.g., '3.5' must not be 3.5.
 
 ---
-author: "Optuna team"
-title: "My Sampler"
-description: "A description for My Sampler."
-tags: ["sampler", "2nd tag for My Sampler", "3rd tag for My Sampler"]
-optuna_versions: ["3.5.0", "3.6.1"]
+author: Optuna team
+title: My Sampler
+description: A description for My Sampler.
+tags: [sampler, 2nd tag for My Sampler, 3rd tag for My Sampler]
+optuna_versions: ['3.5', 3.6.1]
 license: "MIT License"
 ---
 -->
@@ -25,16 +28,20 @@ You can find more detailed explanation of the following contents in the tutorial
 Looking at [other packages' implementations](https://github.com/optuna/optunahub-registry/tree/main/package) will also help you.
 
 ## Class or Function Names
+
 Please fill in the class/function name which you implement here.
 
 ## Installation
+
 If you have additional dependencies, please fill in the installation guide here.
 If no additional dependencies is required, this section can be removed.
 
 ## Example
+
 Please fill in the code snippet to use the implemented feature here.
 
 ## Others
+
 Please fill in any other information if you have here by adding child sections (###).
 If there is no additional information, this section can be removed.
 

--- a/template/README.md
+++ b/template/README.md
@@ -11,7 +11,6 @@ license: MIT License
 This is an example of the frontmatters.
 All columns must be string.
 You can omit quotes when value types are not ambiguous.
-However, quotes are required in ambiguous cases, e.g., '3.5' must not be 3.5.
 For tags, a package placed in
 - package/samplers/ must include the tag "sampler"
 - package/visualilzation/ must include the tag "visualization"
@@ -23,7 +22,7 @@ author: Optuna team
 title: My Sampler
 description: A description for My Sampler.
 tags: [sampler, 2nd tag for My Sampler, 3rd tag for My Sampler]
-optuna_versions: ['3.5', 3.6.1]
+optuna_versions: [3.6.1]
 license: "MIT License"
 ---
 -->


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

## Motivation
- Unify the markdown format by introducing the mdformat formatter.

## Description of the changes
- Add mdformat and mdformat-frontmatter to dependencies
- Add comments to clarify frontmatter values must be a string in the README template
- Add assertions to verify the format of frontmatters
- Apply mdformat to .md files in optunahub-registry (all packages and the remaining files)


FYI
- There doesn't seem to be a string formatting style option in mdformat that forces the use of quotes like "string."
- It would be easier to grasp if read on a commit-by-commit basis since changes are divided into steps.