### PR TITLE
[Proposal] Add seed argument to SimpleBaseSampler

### DIFF
--- a/package/samplers/simple/__init__.py
+++ b/package/samplers/simple/__init__.py
@@ -12,8 +12,11 @@ from optuna.trial import FrozenTrial
 
 
 class SimpleBaseSampler(BaseSampler, abc.ABC):
-    def __init__(self, search_space: dict[str, BaseDistribution] | None = None) -> None:
+    def __init__(
+        self, search_space: dict[str, BaseDistribution] | None = None, seed: int | None = None
+    ) -> None:
         self.search_space = search_space
+        self._seed = seed
         self._init_defaults()
 
     def infer_relative_search_space(
@@ -50,9 +53,12 @@ class SimpleBaseSampler(BaseSampler, abc.ABC):
         # By default, parameter values are sampled by ``optuna.samplers.RandomSampler``.
         return self._default_sample_independent(study, trial, param_name, param_distribution)
 
+    def reseed_rng(self) -> None:
+        self._default_reseed_rng()
+
     def _init_defaults(self) -> None:
         self._intersection_search_space = IntersectionSearchSpace()
-        self._random_sampler = RandomSampler()
+        self._random_sampler = RandomSampler(seed=self._seed)
 
     def _default_infer_relative_search_space(
         self, study: Study, trial: FrozenTrial
@@ -81,3 +87,6 @@ class SimpleBaseSampler(BaseSampler, abc.ABC):
         return self._random_sampler.sample_independent(
             study, trial, param_name, param_distribution
         )
+
+    def _default_reseed_rng(self) -> None:
+        self._random_sampler.reseed_rng()


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

## Motivation

I received feedback from a contributor: " How do I set the random seed for independent sampling in `SimpleBaseSampler`? It is required to make my sampler reproducible." Researchers value reproducibility, so I want to support functionality to set `seed` to `SimpleBaseSampler`.

I think this change possibly needs discussion. If you have any other ideas, please let me know.

## Description of the changes

- Add a `seed` argument and make the seed work properly.
