### PR TITLE
Add `contribution-welcome` label to `package-request` issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/package-request.yml
+++ b/.github/ISSUE_TEMPLATE/package-request.yml
@@ -1,6 +1,6 @@
 name: "\U0001F4A1Package request"
 description: Suggest an idea for new package in OptunaHub.
-labels: ["new-package"]
+labels: ["new-package", "contribution-welcome"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!IMPORTANT]
> The following formatting is a requirement to merge this PR:
>
> ```shell
> $ pip install pre-commit
> $ pre-commit run --all-files
> ```
>
> Please also try the following to make sure that your module can be loaded from the registry:
>
> ```python
> import optunahub
>
> module = optunahub.load_module(
>     # category is one of [pruners, samplers, visualization].
>     package="<category>/<your_package_name>",
>     repo_owner="<your_github_id>",
>     ref="<your_branch_name>",
> )
> ```
>
> For more detail, please check [the tutorial](https://optuna.github.io/optunahub-registry/recipes/005_debugging.html).

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`package-request` issues are almost always `contribution-welcome`. 

## Description of the changes

<!-- Describe the changes in this PR. -->
This PR adds the `contribution-welcome` label to the `package-request` issue template.

I checked the behavior on my fork repository. https://github.com/not522/optunahub-registry