### PR TITLE
Replace `pytorch` with `torch` because `pytorch` is wrong

### DIFF
--- a/package/samplers/gp/README.md
+++ b/package/samplers/gp/README.md
@@ -14,7 +14,7 @@ license: MIT License
 ## Installation
 
 ```bash
-pip install scipy pytorch
+pip install scipy torch
 ```
 
 ## Example


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Replace `pytorch` with `torch`

## Description of the changes

<!-- Describe the changes in this PR. -->
