### PR TITLE
Fix typo in the example notebook for simulated annealing sampler

### DIFF
--- a/package/samplers/simulated_annealing/example.ipynb
+++ b/package/samplers/simulated_annealing/example.ipynb
@@ -68,7 +68,7 @@
    "source": [
     "## Step 3: Load `SimulatedAnnealingSampler`\n",
     "\n",
-    "With `optunahub.load_module`, you can use modules in [Optunanub](https://hub.optuna.org/) in your code.\n",
+    "With `optunahub.load_module`, you can use modules in [OptunaHub](https://hub.optuna.org/) in your code.\n",
     "In this case, a module defined in [samplers/simulated_annealing](https://github.com/optuna/optunahub-registry/tree/main/package/samplers/simulated_annealing) is loaded, and you can instantiate `SimulatedAnnealingSampler` in it."
    ]
   },


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Description of the changes

- Fix typo in `example.ipynb`. Optunanub is a typo for OptunaHub.