### PR TITLE
Fix format of inline code in the tutorial.

### DIFF
--- a/recipes/001_first.py
+++ b/recipes/001_first.py
@@ -13,11 +13,11 @@ If you want to implement algorithms other than a sampler, please refer to the ot
 - :doc:`003_pruner`
 - :doc:`004_visualization`
 
-Usually, Optuna provides `BaseSampler` class to implement your own sampler.
+Usually, Optuna provides ``BaseSampler`` class to implement your own sampler.
 However, it is a bit complicated to implement a sampler from scratch.
 Instead, in OptunaHub, you can use `samplers/simple/SimpleBaseSampler <https://github.com/optuna/optunahub-registry/blob/main/package/samplers/simple/__init__.py>`__ class, which is a sampler template that can be easily extended.
 
-You need to install `optuna` to implement your own sampler, and `optunahub` to use the template `SimpleBaseSampler`.
+You need to install ``optuna`` to implement your own sampler, and ``optunahub`` to use the template ``SimpleBaseSampler``.
 
 .. code-block:: bash
 
@@ -26,7 +26,7 @@ You need to install `optuna` to implement your own sampler, and `optunahub` to u
 """
 
 ###################################################################################################
-# First of all, import `optuna`, `optunahub`, and other required modules.
+# First of all, import ``optuna``, ``optunahub``, and other required modules.
 from __future__ import annotations
 
 from typing import Any
@@ -37,11 +37,11 @@ import optunahub
 
 
 ###################################################################################################
-# Next, define your own sampler class by inheriting `SimpleBaseSampler` class.
+# Next, define your own sampler class by inheriting ``SimpleBaseSampler`` class.
 # In this example, we implement a sampler that returns a random value.
-# `SimpleBaseSampler` class can be loaded using `optunahub.load_module` function.
-# `force_reload=True` argument forces downloading the sampler from the registry.
-# If we set `force_reload` to `False`, we use the cached data in our local storage if available.
+# ``SimpleBaseSampler`` class can be loaded using ``optunahub.load_module`` function.
+# ``force_reload=True`` argument forces downloading the sampler from the registry.
+# If we set ``force_reload`` to :obj:`False`, we use the cached data in our local storage if available.
 
 SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
 
@@ -55,19 +55,19 @@ class MySampler(SimpleBaseSampler):  # type: ignore
         super().__init__(search_space)
         self._rng = np.random.RandomState()
 
-    # You need to implement `sample_relative` method.
+    # You need to implement sample_relative method.
     # This method returns a dictionary of hyperparameters.
-    # The keys of the dictionary are the names of the hyperparameters, which must be the same as the keys of the `search_space` argument.
+    # The keys of the dictionary are the names of the hyperparameters, which must be the same as the keys of the search_space argument.
     # The values of the dictionary are the values of the hyperparameters.
-    # In this example, `sample_relative` method returns a dictionary of randomly sampled hyperparameters.
+    # In this example, sample_relative method returns a dictionary of randomly sampled hyperparameters.
     def sample_relative(
         self,
         study: optuna.study.Study,
         trial: optuna.trial.FrozenTrial,
         search_space: dict[str, optuna.distributions.BaseDistribution],
     ) -> dict[str, Any]:
-        # `search_space` argument must be identical to `search_space` argument input to `__init__` method.
-        # This method is automatically invoked by Optuna and `SimpleBaseSampler`.
+        # search_space argument must be identical to search_space argument input to __init__ method.
+        # This method is automatically invoked by Optuna and SimpleBaseSampler.
 
         # If search space is empty, all parameter values are sampled randomly by SimpleBaseSampler.
         if search_space == {}:
@@ -99,7 +99,7 @@ def objective(trial: optuna.trial.Trial) -> float:
 
 ###################################################################################################
 # This sampler can be used in the same way as other Optuna samplers.
-# In the following example, we create a study and optimize it using `MySampler` class.
+# In the following example, we create a study and optimize it using ``MySampler`` class.
 sampler = MySampler()
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=100)
@@ -118,7 +118,7 @@ print(f"Best params: {best_params}, Best value: {best_value}")
 # In the above examples, search space is estimated at the first trial and updated dynamically through optimization.
 # If your sampler requires the search space to be fixed before optimization, you can pass the search space to the sampler at initialization.
 # Passing the search space also allows the sampler to avoid the overhead of estimating the search space.
-# See `the documentation <https://optuna.readthedocs.io/en/stable/reference/distributions.html>`__ for more information about the optuna.distributions to define search space.
+# See `the documentation <https://optuna.readthedocs.io/en/stable/reference/distributions.html>`__ for more information about the ``optuna.distributions`` to define search space.
 sampler = MySampler(
     search_space={
         "x": optuna.distributions.FloatDistribution(-10, 10),

--- a/recipes/002_registration.py
+++ b/recipes/002_registration.py
@@ -24,21 +24,21 @@ See the `template directory <https://github.com/optuna/optunahub-registry/tree/m
 |             ├──  (figure1.png)
 |             └──  (numerical_results.png)
 
-An implemented algorithm should be put in the corresponding directory, e.g., a sampler should be put in the `samplers` directory.
-In the `samplers` directory, you should create a directory with a unique identifier.
+An implemented algorithm should be put in the corresponding directory, e.g., a sampler should be put in the ``samplers`` directory.
+In the ``samplers`` directory, you should create a directory with a unique identifier.
 This unique identifier is the name of your algorithm package, is used to load the package, and is unable to change once it is registered.
 The package name must be a valid Python module name, preferably one that is easily searchable.
 Abbreviations are not prohibited in package names, but their abuse should be avoided.
 
 The created directory should include the following files:
 
-- `YOUR_ALGORITHM_NAME.py`: The implementation of your algorithm.
-- `__init__.py`: An initialization file. This file must implement your algorithm or import its implementation from another file, e.g., `YOUR_ALGORITHM_NAME.py`.
-- `README.md`: A description of your algorithm. This file is used to create an `web page of OptunaHub <https://hub.optuna.org/>`_. Let me explain the format of the `README.md` file later.
-- `LICENSE`: A license file. This file must contain the license of your algorithm. It should be the MIT license in the alpha version of OptunaHub.
-- `example.py`, `example.ipynb`: This is optional. This file should contain a simple example of how to use your algorithm (Example: `example.py for Simulated Annealing Sampler <https://github.com/optuna/optunahub-registry/blob/main/package/samplers/simulated_annealing/example.py>`_). You can provide examples in both formats.
-- `requirements.txt`: This is optional. A file that contains the additional dependencies of your algorithm. If there are no additional dependencies other than Optuna and OptunaHub, you do not need to create this file.
-- `images`: This is optional. A directory that contains images. Only relative references to images in this directory are allowed in README.md, e.g., ``![Numrical Results](images/numerical_results.png)``, and absolute paths to images are not allowed. The first image that appears in README.md will be used as the thumbnail.
+- ``YOUR_ALGORITHM_NAME.py``: The implementation of your algorithm.
+- ``__init__.py``: An initialization file. This file must implement your algorithm or import its implementation from another file, e.g., ``YOUR_ALGORITHM_NAME.py``.
+- ``README.md``: A description of your algorithm. This file is used to create an `web page of OptunaHub <https://hub.optuna.org/>`_. Let me explain the format of the ``README.md`` file later.
+- ``LICENSE``: A license file. This file must contain the license of your algorithm. It should be the MIT license in the alpha version of OptunaHub.
+- ``example.py``, ``example.ipynb``: This is optional. This file should contain a simple example of how to use your algorithm (Example: `example.py for Simulated Annealing Sampler <https://github.com/optuna/optunahub-registry/blob/main/package/samplers/simulated_annealing/example.py>`_). You can provide examples in both formats.
+- ``requirements.txt``: This is optional. A file that contains the additional dependencies of your algorithm. If there are no additional dependencies other than Optuna and OptunaHub, you do not need to create this file.
+- ``images``: This is optional. A directory that contains images. Only relative references to images in this directory are allowed in README.md, e.g., ``![Numrical Results](images/numerical_results.png)``, and absolute paths to images are not allowed. The first image that appears in README.md will be used as the thumbnail.
 
 All files must pass linter and formetter checks to be merged to the optunahub-registry repository.
 You can check them by running the `pre-commit <https://pre-commit.com/>`__ tool as follows.
@@ -71,12 +71,12 @@ Although we recommend you write proper type hints, if you find it difficult to c
       license: MIT License
       ---
 
-  - `author` (string): The author of the package. It can be your name or your organization name.
-  - `title` (string): The package title. It should not be a class/function name but a human-readable name. For example, `Demo Sampler` is a good title, but `DemoSampler` is not.
-  - `description` (string): A brief description of the package. It should be a one-sentence summary of the package.
-  - `tags` (list[string]): The package tags. It should be a list of strings. The tags must include `sampler`, `visualization`, or `pruner` depending on the type of the package. You can add other tags as needed. For example, "['sampler', 'LLM']".
-  - `optuna_versions` (list[string]): A list of Optuna versions that the package supports. It should be a list of strings. You can find your Optuna version with `python -c 'import optuna; print(optuna.__version__)'`.
-  - `license` (string): The license of the package. It should be a string. For example, `MIT License`. The license must be `MIT License` in the current version of OptunaHub.
+  - ``author`` (string): The author of the package. It can be your name or your organization name.
+  - ``title`` (string): The package title. It should not be a class/function name but a human-readable name. For example, `Demo Sampler` is a good title, but `DemoSampler` is not.
+  - ``description`` (string): A brief description of the package. It should be a one-sentence summary of the package.
+  - ``tags`` (list[string]): The package tags. It should be a list of strings. The tags must include ``sampler``, ``visualization``, or ``pruner`` depending on the type of the package. You can add other tags as needed. For example, "['sampler', 'LLM']".
+  - ``optuna_versions`` (list[string]): A list of Optuna versions that the package supports. It should be a list of strings. You can find your Optuna version with ``python -c 'import optuna; print(optuna.__version__)'``.
+  - ``license`` (string): The license of the package. It should be a string. For example, `MIT License`. The license must be `MIT License` in the current version of OptunaHub.
 
 - `Abstract <https://github.com/optuna/optunahub-registry/blob/main/template/README.md#abstract>`__ section that describes the summary of your package. It should be a markdown paragraph. This section will help attract potential users to your package.
 
@@ -94,7 +94,7 @@ Although we recommend you write proper type hints, if you find it difficult to c
 
       $ pip install -r requirements.txt
 
-- An `Example <https://github.com/optuna/optunahub-registry/blob/main/template/README.md#example>`__ section that describes how to use the package. It should be a python code block. It should be a few lines of code snippets that show how to use the package. If you want to provide a full example, please create a separete file like `example.py` and refer to it. For example:
+- An `Example <https://github.com/optuna/optunahub-registry/blob/main/template/README.md#example>`__ section that describes how to use the package. It should be a python code block. It should be a few lines of code snippets that show how to use the package. If you want to provide a full example, please create a separete file like ``example.py`` and refer to it. For example:
 
   .. code-block:: markdown
 
@@ -113,7 +113,7 @@ Although we recommend you write proper type hints, if you find it difficult to c
 
 It is highly recommended that you confirm your package works properly (cf. :doc:`005_debugging`) before making a pull request.
 
-Before making a pull request, please ensure the code examples in README.md and example.py do not contain your local directory and/or your fork of the registry.
+Before making a pull request, please ensure the code examples in ``README.md`` and example.py do not contain your local directory and/or your fork of the registry.
 Code such as ``load_local_module("your_package", registry_root=”your_local_directory”)`` or ``load_module("your_package_name", repo_owner=”your_github_id”, ref=”your_working_branch”)`` should be ``load_module("your_package_name")``.
 
 After merging your pull request, your package will be available on the `OptunaHub <https://hub.optuna.org/>`__ in about 1 hour.

--- a/recipes/004_visualization.py
+++ b/recipes/004_visualization.py
@@ -20,7 +20,7 @@ import plotly.graph_objects as go
 
 
 ###################################################################################################
-# If you use `plotly` (https://plotly.com/python/) for visualization, the function should return a `plotly.graph_objects.Figure` object.
+# If you use `plotly <https://plotly.com/python/>`__ for visualization, the function should return a ``plotly.graph_objects.Figure`` object.
 
 
 def plot_optimizaiton_history(study: optuna.study.Study) -> go.Figure:
@@ -42,7 +42,7 @@ def plot_optimizaiton_history(study: optuna.study.Study) -> go.Figure:
 
 
 ###################################################################################################
-# If you use `matplotlib` (https://matplotlib.org/) for visualization, the function should return a `matplotlib.figure.Figure` object.
+# If you use `matplotlib <https://matplotlib.org/>`__ for visualization, the function should return a ``matplotlib.figure.Figure`` object.
 
 
 def plot_optimizaiton_history_matplotlib(study: optuna.study.Study) -> matplotlib.figure.Figure:

--- a/recipes/005_debugging.py
+++ b/recipes/005_debugging.py
@@ -25,7 +25,7 @@ First, you can use the `optunahub.load_local_module <https://optuna.github.io/op
 Load Your Package from Your Fork of The optunahub-registry Repository
 ---------------------------------------------------------------------
 
-Second, you can use the `optunahub.load_module <https://optuna.github.io/optunahub/reference.html#optunahub.load_module>`__ function with `repo_owner={YOUR_GITHUB_ID}` and `ref={YOUR_BRANCH_NAME}` to load your package from your fork of the optunahub-registry repository and check if it works correctly.
+Second, you can use the `optunahub.load_module <https://optuna.github.io/optunahub/reference.html#optunahub.load_module>`__ function with ``repo_owner={YOUR_GITHUB_ID}`` and ``ref={YOUR_BRANCH_NAME}`` to load your package from your fork of the optunahub-registry repository and check if it works correctly.
 
 .. code-block:: python
 


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

## Motivation

We usually use double-backquotes for inline code blocks.
But we can see single-backquoted code blocks in the tutorial.

## Description of the changes

Fix format of inline code