### PR TITLE
Shorten URLs of requirements.txt

### DIFF
--- a/package/samplers/catcma/README.md
+++ b/package/samplers/catcma/README.md
@@ -24,7 +24,7 @@ This figure is from https://arxiv.org/abs/2405.09962.
 ## Installation
 
 ```bash
-pip install -r requirements.txt
+pip install -r https://hub.optuna.org/samplers/catcma/requirements.txt
 ```
 
 ## Example

--- a/package/samplers/gp_pims/README.md
+++ b/package/samplers/gp_pims/README.md
@@ -34,7 +34,7 @@ license: "MIT License"
 ## Installation
 
 ```shell
-$ pip install -r requirements.txt
+$ pip install -r https://hub.optuna.org/samplers/gp_pims/requirements.txt
 ```
 
 ## Example

--- a/package/samplers/hebo/README.md
+++ b/package/samplers/hebo/README.md
@@ -14,7 +14,7 @@ license: MIT License
 ## Installation
 
 ```bash
-pip install -r requirements.txt
+pip install -r https://hub.optuna.org/samplers/hebo/requirements.txt
 git clone git@github.com:huawei-noah/HEBO.git
 cd HEBO/HEBO
 pip install -e .

--- a/package/samplers/nelder_mead/README.md
+++ b/package/samplers/nelder_mead/README.md
@@ -20,7 +20,7 @@ This Nelder-Mead method implemenation employs the effective initialization metho
 ## Installation
 
 ```bash
-pip install -r https://raw.githubusercontent.com/optuna/optunahub-registry/main/package/samplers/nelder_mead/requirements.txt
+pip install -r https://hub.optuna.org/samplers/nelder_mead/requirements.txt
 ```
 
 ## Example

--- a/package/samplers/pfns4bo/README.md
+++ b/package/samplers/pfns4bo/README.md
@@ -14,7 +14,7 @@ license: MIT License
 ## Installation
 
 ```bash
-pip install -r requirements.txt
+pip install -r https://hub.optuna.org/samplers/pfns4bo/requirements.txt
 ```
 
 ## Example

--- a/package/samplers/pfns4bo/example.ipynb
+++ b/package/samplers/pfns4bo/example.ipynb
@@ -42,8 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!curl -LO https://raw.githubusercontent.com/optuna/optunahub-registry/main/package/samplers/pfns4bo/requirements.txt\n",
-    "%pip install -q --progress-bar off -r requirements.txt\n",
+    "%pip install -q --progress-bar off -r https://hub.optuna.org/samplers/pfns4bo/requirements.txt\n",
     "%pip install -q --progress-bar off optunahub pfns4bo"
    ]
   },

--- a/package/samplers/plmbo/README.md
+++ b/package/samplers/plmbo/README.md
@@ -14,7 +14,7 @@ license: MIT License
 ## Installation
 
 ```sh
-pip install -r https://raw.githubusercontent.com/optuna/optunahub-registry/main/package/samplers/plmbo/requirements.txt
+pip install -r https://hub.optuna.org/samplers/plmbo/requirements.txt
 ```
 
 ## Example

--- a/package/samplers/uniform_design/README.md
+++ b/package/samplers/uniform_design/README.md
@@ -19,7 +19,7 @@ UD is a variety of design-of-experiment (DOE) methods, and it has better sample 
 ## Installation
 
 ```shell
-$ pip install -r requirements.txt
+$ pip install -r https://hub.optuna.org/samplers/uniform_design/requirements.txt
 ```
 
 ## Example


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

This PR depends on https://github.com/optuna/optunahub-web/pull/40.

Currently, package installation is explained as follows:

```bash
pip install -r requirements.txt
```

or

```bash
pip install -r https://raw.githubusercontent.com/optuna/optunahub-registry/main/package/samplers/name/requirements.txt
```

The former is not executable since the `requirements.txt` file does not necessarily exist in users' environments, and the latter might be a bit long.

This PR unifies them by using the URLs introduced by https://github.com/optuna/optunahub-web/pull/40 as follows:

```bash
pip install -r https://hub.optuna.org/samplers/name/requirements.txt
```

## Description of the changes

- Update the installation of each package
 
