### PR TITLE
Update optuna version to 4.0.0.

### DIFF
--- a/recipes/002_registration.py
+++ b/recipes/002_registration.py
@@ -67,7 +67,7 @@ Although we recommend you write proper type hints, if you find it difficult to c
       title: Demo Sampler
       description: Demo Sampler of OptunaHub
       tags: [sampler]
-      optuna_versions: [3.6.1]
+      optuna_versions: [4.0.0]
       license: MIT License
       ---
 


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.


## Motivation

Update optuna version in the tutorial since v4.0.0 will be released soon.

## Description of the changes

- Change optuna version from 3.6.1 to 4.0.0.