### PR TITLE
Add CMA-ES with user prior

### DIFF
--- a/package/samplers/user_prior_cmaes/LICENSE
+++ b/package/samplers/user_prior_cmaes/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Shuhei Watanabe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/samplers/user_prior_cmaes/README.md
+++ b/package/samplers/user_prior_cmaes/README.md
@@ -15,6 +15,14 @@ As the Optuna CMA-ES sampler does not support any flexible ways to initialize th
 
 - UserPriorCmaEsSampler
 
+In principle, most arguments follow [`optuna.samplers.CmaEsSampler`](https://optuna.readthedocs.io/en/stable/reference/samplers/generated/optuna.samplers.CmaEsSampler.html), but some parts are modified.
+
+For example, `UserPriorCmaEsSampler` does not support `source_trials` and `use_separable_cma` due to their incompatibility.
+Instead, we replaced `x0` and `sigma0` in `CmaEsSampler` with `mu0` and `cov0`.
+In `CmaEsSampler`, we needed to provide `x0` as `dict` and `sigma0` only as `float`.
+By adding `param_names` to the requirement, we can now give `mu0` (previously `x0`) and `cov0` (previously `sigma0`) as `np.ndarray`.
+Note that the order of each dimension in `mu0` and `cov0` must be consistent with that in `param_names`.
+
 ## Installation
 
 ```shell

--- a/package/samplers/user_prior_cmaes/README.md
+++ b/package/samplers/user_prior_cmaes/README.md
@@ -47,7 +47,7 @@ def objective(trial: optuna.Trial) -> float:
 
 if __name__ == "__main__":
     module = optunahub.load_module(package="samplers/user_prior_cmaes")
-    sampler = module.UserPriorCmaEsSampler(param_names=["x", "y"], mu0=np.array([3., -48.]), cov0=np.diag([0.2, 2.0]))
+    sampler = module.UserPriorCmaEsSampler(param_names=["x", "y"], mu0=np.array([-48., 3.]), cov0=np.diag([2., 0.2]))
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=20)
     print(study.best_trial.value, study.best_trial.params)

--- a/package/samplers/user_prior_cmaes/README.md
+++ b/package/samplers/user_prior_cmaes/README.md
@@ -1,75 +1,27 @@
 ---
-author: Please fill in the author name here. (e.g., John Smith)
-title: Please fill in the title of the feature here. (e.g., Gaussian-Process Expected Improvement Sampler)
-description: Please fill in the description of the feature here. (e.g., This sampler searches for each trial based on expected improvement using Gaussian process.)
-tags: [Please fill in the list of tags here. (e.g., sampler, visualization, pruner)]
-optuna_versions: ['Please fill in the list of versions of Optuna in which you have confirmed the feature works, e.g., 3.6.1.']
+author: Shuhei Watanabe
+title: CMA-ES with User Prior
+description: You can provide the initial parameters, i.e. mean vector and covariance matrix, for CMA-ES with this sampler.
+tags: [sampler, cma-es, meta-learning, prior]
+optuna_versions: [4.0.0]
 license: MIT License
 ---
 
-<!--
-This is an example of the frontmatters.
-All columns must be string.
-You can omit quotes when value types are not ambiguous.
-For tags, a package placed in
-- package/samplers/ must include the tag "sampler"
-- package/visualilzation/ must include the tag "visualization"
-- package/pruners/ must include the tag "pruner"
-respectively.
-
----
-author: Optuna team
-title: My Sampler
-description: A description for My Sampler.
-tags: [sampler, 2nd tag for My Sampler, 3rd tag for My Sampler]
-optuna_versions: [3.6.1]
-license: "MIT License"
----
--->
-
-Please read the [tutorial guide](https://optuna.github.io/optunahub-registry/recipes/001_first.html) to register your feature in OptunaHub.
-You can find more detailed explanation of the following contents in the tutorial.
-Looking at [other packages' implementations](https://github.com/optuna/optunahub-registry/tree/main/package) will also help you.
-
 ## Abstract
 
-You can provide an abstract for your package here.
-This section will help attract potential users to your package.
-
-**Example**
-
-This package provides a sampler based on Gaussian process-based Bayesian optimization. The sampler is highly sample-efficient, so it is suitable for computationally expensive optimization problems with a limited evaluation budget, such as hyperparameter optimization of machine learning algorithms.
+As the Optuna CMA-ES sampler does not support any flexible ways to initialize the parameters of the Gaussian distribution, so I created a workaround to do so.
 
 ## Class or Function Names
 
-Please fill in the class/function names which you implement here.
-
-**Example**
-
-- GPSampler
+- UserPriorCmaEsSampler
 
 ## Installation
 
-If you have additional dependencies, please fill in the installation guide here.
-If no additional dependencies is required, **this section can be removed**.
-
-**Example**
-
 ```shell
-$ pip install scipy torch
-```
-
-If your package has `requirements.txt`, it will be automatically uploaded to the OptunaHub, and the package dependencies will be available to install as follows.
-
-```shell
- pip install -r https://hub.optuna.org/{category}/{your_package_name}/requirements.txt
+$ pip install optunahub cmaes
 ```
 
 ## Example
-
-Please fill in the code snippet to use the implemented feature here.
-
-**Example**
 
 ```python
 import optuna

--- a/package/samplers/user_prior_cmaes/README.md
+++ b/package/samplers/user_prior_cmaes/README.md
@@ -47,7 +47,10 @@ def objective(trial: optuna.Trial) -> float:
 
 if __name__ == "__main__":
     module = optunahub.load_module(package="samplers/user_prior_cmaes")
-    sampler = module.UserPriorCmaEsSampler(param_names=["x", "y"], mu0=np.array([-48., 3.]), cov0=np.diag([2., 0.2]))
+    # ``with_margin=True`` because the search space has an integer parameter.
+    sampler = module.UserPriorCmaEsSampler(
+        param_names=["x", "y"], mu0=np.array([-48., 3.]), cov0=np.diag([2., 0.2]), with_margin=True
+    )
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=20)
     print(study.best_trial.value, study.best_trial.params)

--- a/package/samplers/user_prior_cmaes/README.md
+++ b/package/samplers/user_prior_cmaes/README.md
@@ -1,0 +1,110 @@
+---
+author: Please fill in the author name here. (e.g., John Smith)
+title: Please fill in the title of the feature here. (e.g., Gaussian-Process Expected Improvement Sampler)
+description: Please fill in the description of the feature here. (e.g., This sampler searches for each trial based on expected improvement using Gaussian process.)
+tags: [Please fill in the list of tags here. (e.g., sampler, visualization, pruner)]
+optuna_versions: ['Please fill in the list of versions of Optuna in which you have confirmed the feature works, e.g., 3.6.1.']
+license: MIT License
+---
+
+<!--
+This is an example of the frontmatters.
+All columns must be string.
+You can omit quotes when value types are not ambiguous.
+For tags, a package placed in
+- package/samplers/ must include the tag "sampler"
+- package/visualilzation/ must include the tag "visualization"
+- package/pruners/ must include the tag "pruner"
+respectively.
+
+---
+author: Optuna team
+title: My Sampler
+description: A description for My Sampler.
+tags: [sampler, 2nd tag for My Sampler, 3rd tag for My Sampler]
+optuna_versions: [3.6.1]
+license: "MIT License"
+---
+-->
+
+Please read the [tutorial guide](https://optuna.github.io/optunahub-registry/recipes/001_first.html) to register your feature in OptunaHub.
+You can find more detailed explanation of the following contents in the tutorial.
+Looking at [other packages' implementations](https://github.com/optuna/optunahub-registry/tree/main/package) will also help you.
+
+## Abstract
+
+You can provide an abstract for your package here.
+This section will help attract potential users to your package.
+
+**Example**
+
+This package provides a sampler based on Gaussian process-based Bayesian optimization. The sampler is highly sample-efficient, so it is suitable for computationally expensive optimization problems with a limited evaluation budget, such as hyperparameter optimization of machine learning algorithms.
+
+## Class or Function Names
+
+Please fill in the class/function names which you implement here.
+
+**Example**
+
+- GPSampler
+
+## Installation
+
+If you have additional dependencies, please fill in the installation guide here.
+If no additional dependencies is required, **this section can be removed**.
+
+**Example**
+
+```shell
+$ pip install scipy torch
+```
+
+If your package has `requirements.txt`, it will be automatically uploaded to the OptunaHub, and the package dependencies will be available to install as follows.
+
+```shell
+ pip install -r https://hub.optuna.org/{category}/{your_package_name}/requirements.txt
+```
+
+## Example
+
+Please fill in the code snippet to use the implemented feature here.
+
+**Example**
+
+```python
+import optuna
+import optunahub
+
+
+def objective(trial):
+  x = trial.suggest_float("x", -5, 5)
+  return x**2
+
+
+sampler = optunahub.load_module(package="samplers/gp").GPSampler()
+study = optuna.create_study(sampler=sampler)
+study.optimize(objective, n_trials=100)
+```
+
+## Others
+
+Please fill in any other information if you have here by adding child sections (###).
+If there is no additional information, **this section can be removed**.
+
+<!--
+For example, you can add sections to introduce a corresponding paper.
+
+### Reference
+Takuya Akiba, Shotaro Sano, Toshihiko Yanase, Takeru Ohta, and Masanori Koyama. 2019.
+Optuna: A Next-generation Hyperparameter Optimization Framework. In KDD.
+
+### Bibtex
+```
+@inproceedings{optuna_2019,
+    title={Optuna: A Next-generation Hyperparameter Optimization Framework},
+    author={Akiba, Takuya and Sano, Shotaro and Yanase, Toshihiko and Ohta, Takeru and Koyama, Masanori},
+    booktitle={Proceedings of the 25th {ACM} {SIGKDD} International Conference on Knowledge Discovery and Data Mining},
+    year={2019}
+}
+```
+-->

--- a/package/samplers/user_prior_cmaes/__init__.py
+++ b/package/samplers/user_prior_cmaes/__init__.py
@@ -1,0 +1,4 @@
+from .sampler import UserPriorCmaEsSampler
+
+
+__all__ = ["UserPriorCmaEsSampler"]

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -108,6 +108,7 @@ class UserPriorCmaEsSampler(CmaEsSampler):
                 "The most probable reason is duplicated names in param_names."
             )
         elif len(search_space) != 0:
+            # Ensure the parameter order is identical to that in param_names.
             search_space = {
                 param_name: search_space[param_name] for param_name in self._param_names
             }

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -103,7 +103,10 @@ class UserPriorCmaEsSampler(CmaEsSampler):
         search_space: dict[str, BaseDistribution],
     ) -> dict[str, Any]:
         if len(search_space) != 0 and set(search_space.keys()) != set(self._param_names):
-            raise
+            raise ValueError(
+                "The keys in search_space and param_names did not match. "
+                "The most probable reason is duplicated names in param_names."
+            )
         elif len(search_space) != 0:
             search_space = {
                 param_name: search_space[param_name] for param_name in self._param_names

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -11,8 +11,8 @@ from optuna.distributions import BaseDistribution
 from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.samplers import BaseSampler
-from optuna.samplers import CmaClass
 from optuna.samplers import CmaEsSampler
+from optuna.samplers._cmaes import CmaClass
 from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
 

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from typing import Any
+from typing import Union
 
 import cmaes
 import numpy as np
@@ -12,9 +13,11 @@ from optuna.distributions import FloatDistribution
 from optuna.distributions import IntDistribution
 from optuna.samplers import BaseSampler
 from optuna.samplers import CmaEsSampler
-from optuna.samplers._cmaes import CmaClass
 from optuna.study import StudyDirection
 from optuna.trial import FrozenTrial
+
+
+CmaClass = Union[cmaes.CMA, cmaes.SepCMA, cmaes.CMAwM]
 
 
 class UserPriorCmaEsSampler(CmaEsSampler):

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -137,14 +137,16 @@ class UserPriorCmaEsSampler(CmaEsSampler):
 
         mu0 = self._mu0.copy()
         mu0[is_single] = 0.5
+        # Clip into [0, 1].
         mu0[~is_single] = (mu0[~is_single] - raw_bounds[~is_single, 0]) / domain_sizes[~is_single]
 
+        # We also need to transform the covariance matrix accordingly to adapt to the [0, 1] scale.
         cov0 = self._cov0 / (domain_sizes * domain_sizes[:, np.newaxis])
+
+        # Make the determinant of cov0 1 so that it agrees with the CMA-ES convention.
         sigma0 = math.pow(np.linalg.det(cov0), 1.0 / 2.0 / dim)
         # Avoid ZeroDivisionError in cmaes.
         sigma0 = max(sigma0, 1e-10)
-
-        # Make the determinant of cov0 1 so that it agrees with the CMA-ES convention.
         cov0 /= sigma0**2
 
         return mu0, sigma0, cov0

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -72,8 +72,8 @@ class UserPriorCmaEsSampler(CmaEsSampler):
         )
         self._validate_user_prior(param_names, mu0, cov0)
         self._param_names = param_names[:]
-        self._mu0 = mu0.copy()
-        self._cov0 = cov0.copy()
+        self._mu0 = mu0.astype(float)
+        self._cov0 = cov0.astype(float)
 
     def _validate_user_prior(
         self, param_names: list[str], mu0: np.ndarray, cov0: np.ndarray

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -157,7 +157,7 @@ class UserPriorCmaEsSampler(CmaEsSampler):
         randomize_start_point: bool = False,
     ) -> CmaClass:
         n_dimension = len(trans.bounds)
-        mu0, sigma0, cov0 = self._calculate_initial_params(trans._search_space)
+        mu0, sigma0, cov0 = self._calculate_initial_params(trans)
 
         if self._with_margin:
             steps = np.empty(len(trans._search_space), dtype=float)

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -117,6 +117,10 @@ class UserPriorCmaEsSampler(CmaEsSampler):
     def _calculate_initial_params(
         self, trans: _SearchSpaceTransform
     ) -> tuple[np.ndarray, float, np.ndarray]:
+        # NOTE(nabenabe): Except this method, everything is basically based on Optuna v4.0.0.
+        # As this class does not support some cases supported by Optuna, I simply added validation
+        # to each method, but otherwise, nothing changed. In principle, if users find a bug, it is
+        # likely that the bug exists in this method.
         search_space = trans._search_space.copy()
         if any(
             not isinstance(d, (IntDistribution, FloatDistribution)) for d in search_space.values()

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import cmaes
+import numpy as np
+from optuna import Study
+from optuna._transform import _SearchSpaceTransform
+from optuna.distributions import BaseDistribution
+from optuna.distributions import FloatDistribution
+from optuna.distributions import IntDistribution
+from optuna.samplers import BaseSampler
+from optuna.samplers import CmaClass
+from optuna.samplers import CmaEsSampler
+from optuna.study import StudyDirection
+from optuna.trial import FrozenTrial
+
+
+class UserPriorCmaEsSampler(CmaEsSampler):
+    """A sampler using `cmaes <https://github.com/CyberAgentAILab/cmaes>`__ as the backend with user prior.
+
+    Please check ``CmaEsSampler`` in Optuna for more details of each argument.
+    This class modified the arguments ``x0`` and ``sigma0`` in ``CmaEsSampler`` of Optuna.
+    Furthermore, due to the incompatibility,
+    This class does not support ``source_trials`` and ``use_separable_cma`` due to their incompatibility.
+
+    Args:
+        x0:
+            A dictionary of an initial parameter values for CMA-ES. By default, the mean of ``low``
+            and ``high`` for each distribution is used. Note that ``x0`` is sampled uniformly
+            within the search space domain for each restart if you specify ``restart_strategy``
+            argument.
+
+        sigma0:
+            Initial standard deviation of CMA-ES. By default, ``sigma0`` is set to
+            ``min_range / 6``, where ``min_range`` denotes the minimum range of the distributions
+            in the search space.
+    """  # NOQA: E501
+
+    def __init__(
+        self,
+        param_names: list[str],
+        mu0: np.ndarray,
+        cov0: np.ndarray,
+        n_startup_trials: int = 1,
+        independent_sampler: BaseSampler | None = None,
+        warn_independent_sampling: bool = True,
+        seed: int | None = None,
+        *,
+        consider_pruned_trials: bool = False,
+        restart_strategy: str | None = None,
+        popsize: int | None = None,
+        inc_popsize: int = 2,
+        with_margin: bool = False,
+        lr_adapt: bool = False,
+    ) -> None:
+        super().__init__(
+            x0=None,
+            sigma0=None,
+            n_startup_trials=n_startup_trials,
+            independent_sampler=independent_sampler,
+            warn_independent_sampling=warn_independent_sampling,
+            seed=seed,
+            consider_pruned_trials=consider_pruned_trials,
+            restart_strategy=restart_strategy,
+            popsize=popsize,
+            inc_popsize=inc_popsize,
+            use_separable_cma=False,
+            with_margin=with_margin,
+            lr_adapt=lr_adapt,
+            source_trials=None,
+        )
+        self._validate_user_prior(param_names, mu0, cov0)
+        dim = len(param_names)
+        self._param_names = param_names[:]
+        self._mu0 = mu0.copy()
+        self._sigma0 = math.pow(np.linalg.det(cov0), 1.0 / 2.0 / dim)
+        # Make the determinant of cov0 1 so that it agrees with the CMA-ES convention.
+        self._cov0 = cov0.copy() / self._sigma0**2
+
+    def _validate_user_prior(
+        self, param_names: list[str], mu0: np.ndarray, cov0: np.ndarray
+    ) -> None:
+        dim = len(param_names)
+        if dim != len(set(param_names)):
+            raise ValueError(
+                "Some elements in param_names are duplicated. Please make it a unique list."
+            )
+        if mu0.shape != (dim,) or cov0.shape != (dim, dim):
+            raise ValueError(
+                f"The shape of mu0 and cov0 must be (len(param_names)={dim}, ) and "
+                f"(len(param_names)={dim}, len(param_names)={dim}), but got {mu0.shape} and "
+                f"{cov0.shape}."
+            )
+        if not np.allclose(cov0, cov0.T):
+            raise ValueError("cov0 must be a symmetric matrix.")
+        if np.any(cov0 < 0.0):
+            raise ValueError("All elements in cov0 must be non-negative.")
+        if np.any(np.linalg.eigvals(cov0) < 0.0):
+            raise ValueError("cov0 must be a semi-positive definite matrix.")
+
+    def sample_relative(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        search_space: dict[str, BaseDistribution],
+    ) -> dict[str, Any]:
+        if len(search_space) != 0 and set(search_space.keys()) != set(self._param_names):
+            raise
+        elif len(search_space) != 0:
+            search_space = {
+                param_name: search_space[param_name] for param_name in self._param_names
+            }
+
+        return super().sample_relative(study=study, trial=trial, search_space=search_space)
+
+    def _init_optimizer(
+        self,
+        trans: _SearchSpaceTransform,
+        direction: StudyDirection,
+        population_size: int | None = None,
+        randomize_start_point: bool = False,
+    ) -> CmaClass:
+        n_dimension = len(trans.bounds)
+        mean = self._mu0.copy()
+        cov = self._cov0.copy()
+
+        # Avoid ZeroDivisionError in cmaes.
+        sigma0 = max(self._sigma0, 1e-10)
+
+        if self._with_margin:
+            steps = np.empty(len(trans._search_space), dtype=float)
+            for i, dist in enumerate(trans._search_space.values()):
+                assert isinstance(dist, (IntDistribution, FloatDistribution))
+                # Set step 0.0 for continuous search space.
+                if dist.step is None or dist.log:
+                    steps[i] = 0.0
+                elif dist.low == dist.high:
+                    steps[i] = 1.0
+                else:
+                    steps[i] = dist.step / (dist.high - dist.low)
+
+            return cmaes.CMAwM(
+                mean=mean,
+                sigma=sigma0,
+                bounds=trans.bounds,
+                steps=steps,
+                cov=cov,
+                seed=self._cma_rng.rng.randint(1, 2**31 - 2),
+                n_max_resampling=10 * n_dimension,
+                population_size=population_size,
+            )
+
+        return cmaes.CMA(
+            mean=mean,
+            sigma=sigma0,
+            cov=cov,
+            bounds=trans.bounds,
+            seed=self._cma_rng.rng.randint(1, 2**31 - 2),
+            n_max_resampling=10 * n_dimension,
+            population_size=population_size,
+            lr_adapt=self._lr_adapt,
+        )

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -29,16 +29,12 @@ class UserPriorCmaEsSampler(CmaEsSampler):
     This class does not support ``source_trials`` and ``use_separable_cma`` due to their incompatibility.
 
     Args:
-        x0:
-            A dictionary of an initial parameter values for CMA-ES. By default, the mean of ``low``
-            and ``high`` for each distribution is used. Note that ``x0`` is sampled uniformly
-            within the search space domain for each restart if you specify ``restart_strategy``
-            argument.
-
-        sigma0:
-            Initial standard deviation of CMA-ES. By default, ``sigma0`` is set to
-            ``min_range / 6``, where ``min_range`` denotes the minimum range of the distributions
-            in the search space.
+        param_names:
+            The list of the parameter names to be tuned. This list must be a unique list.
+        mu0:
+            The mean vector used for the initialization of CMA-ES.
+        cov0:
+            The covariance matrix used for the initialization of CMA-ES.
     """  # NOQA: E501
 
     def __init__(
@@ -75,12 +71,9 @@ class UserPriorCmaEsSampler(CmaEsSampler):
             source_trials=None,
         )
         self._validate_user_prior(param_names, mu0, cov0)
-        dim = len(param_names)
         self._param_names = param_names[:]
         self._mu0 = mu0.copy()
-        self._sigma0 = math.pow(np.linalg.det(cov0), 1.0 / 2.0 / dim)
-        # Make the determinant of cov0 1 so that it agrees with the CMA-ES convention.
-        self._cov0 = cov0.copy() / self._sigma0**2
+        self._cov0 = cov0.copy()
 
     def _validate_user_prior(
         self, param_names: list[str], mu0: np.ndarray, cov0: np.ndarray
@@ -118,6 +111,44 @@ class UserPriorCmaEsSampler(CmaEsSampler):
 
         return super().sample_relative(study=study, trial=trial, search_space=search_space)
 
+    def _calculate_initial_params(
+        self, trans: _SearchSpaceTransform
+    ) -> tuple[np.ndarray, float, np.ndarray]:
+        search_space = trans._search_space.copy()
+        if any(
+            not isinstance(d, (IntDistribution, FloatDistribution)) for d in search_space.values()
+        ):
+            raise ValueError("search_space cannot include categorical parameters.")
+        if any(
+            d.log
+            for d in search_space.values()
+            if isinstance(d, (FloatDistribution, IntDistribution))
+        ):
+            src_url = "https://hub.optuna.org/samplers/user_prior_cmaes/"
+            raise ValueError(
+                "search_space for user_prior cannot include log scale. "
+                f"Please use the workaround described in {src_url}."
+            )
+
+        dim = len(self._param_names)
+        raw_bounds = trans._raw_bounds
+        domain_sizes = raw_bounds[:, 1] - raw_bounds[:, 0]
+        is_single = domain_sizes == 0.0
+
+        mu0 = self._mu0.copy()
+        mu0[is_single] = 0.5
+        mu0[~is_single] = (mu0[~is_single] - raw_bounds[~is_single, 0]) / domain_sizes[~is_single]
+
+        cov0 = self._cov0 / (domain_sizes * domain_sizes[:, np.newaxis])
+        sigma0 = math.pow(np.linalg.det(cov0), 1.0 / 2.0 / dim)
+        # Avoid ZeroDivisionError in cmaes.
+        sigma0 = max(self._sigma0, 1e-10)
+
+        # Make the determinant of cov0 1 so that it agrees with the CMA-ES convention.
+        cov0 /= sigma0**2
+
+        return mu0, sigma0, cov0
+
     def _init_optimizer(
         self,
         trans: _SearchSpaceTransform,
@@ -126,11 +157,7 @@ class UserPriorCmaEsSampler(CmaEsSampler):
         randomize_start_point: bool = False,
     ) -> CmaClass:
         n_dimension = len(trans.bounds)
-        mean = self._mu0.copy()
-        cov = self._cov0.copy()
-
-        # Avoid ZeroDivisionError in cmaes.
-        sigma0 = max(self._sigma0, 1e-10)
+        mu0, sigma0, cov0 = self._calculate_initial_params(trans._search_space)
 
         if self._with_margin:
             steps = np.empty(len(trans._search_space), dtype=float)
@@ -145,20 +172,20 @@ class UserPriorCmaEsSampler(CmaEsSampler):
                     steps[i] = dist.step / (dist.high - dist.low)
 
             return cmaes.CMAwM(
-                mean=mean,
+                mean=mu0,
                 sigma=sigma0,
                 bounds=trans.bounds,
                 steps=steps,
-                cov=cov,
+                cov=cov0,
                 seed=self._cma_rng.rng.randint(1, 2**31 - 2),
                 n_max_resampling=10 * n_dimension,
                 population_size=population_size,
             )
 
         return cmaes.CMA(
-            mean=mean,
+            mean=mu0,
             sigma=sigma0,
-            cov=cov,
+            cov=cov0,
             bounds=trans.bounds,
             seed=self._cma_rng.rng.randint(1, 2**31 - 2),
             n_max_resampling=10 * n_dimension,

--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -142,7 +142,7 @@ class UserPriorCmaEsSampler(CmaEsSampler):
         cov0 = self._cov0 / (domain_sizes * domain_sizes[:, np.newaxis])
         sigma0 = math.pow(np.linalg.det(cov0), 1.0 / 2.0 / dim)
         # Avoid ZeroDivisionError in cmaes.
-        sigma0 = max(self._sigma0, 1e-10)
+        sigma0 = max(sigma0, 1e-10)
 
         # Make the determinant of cov0 1 so that it agrees with the CMA-ES convention.
         cov0 /= sigma0**2


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

As the current CMA-ES implementation does not allow users to give an initial covariance matrix, I modified the CMA-ES so that we can provide a covariance matrix from the user side.

## Description of the changes

<!-- Describe the changes in this PR. -->

- Add the CMA-ES with user prior

## TODO List towards PR Merge

Please remove this section if this PR is not an addition of a new package.
Otherwise, please check the following TODO list:


- [x] Copy `./template/` to create your package
- [x] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [x] Fill out `README.md` in your package
- [x] Add import statements of your function or class names to be used in `__init__.py`
- [x] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [x] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
