### PR TITLE
Fix example for MO-CMA-ES

### DIFF
--- a/package/samplers/mocma/README.md
+++ b/package/samplers/mocma/README.md
@@ -43,7 +43,7 @@ def objective(trial: optuna.Trial) -> tuple[float, float]:
     return v0, v1
 
 samplers = [
-    optunahub.load_local_module("samplers/mocma", registry_root="package").MoCmaSampler(popsize=100, seed=42),
+    optunahub.load_module("samplers/mocma").MoCmaSampler(popsize=100, seed=42),
     optuna.samplers.NSGAIISampler(population_size=100, seed=42),
 ]
 studies = []

--- a/package/samplers/mocma/example.py
+++ b/package/samplers/mocma/example.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
         return v0, v1
 
     samplers = [
-        optunahub.load_local_module("samplers/mocma", registry_root="package").MoCmaSampler(
+        optunahub.load_module("samplers/mocma").MoCmaSampler(
             popsize=100,
             seed=42,
         ),


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation & Description of the changes

Current examples use `load_local_module`, which does not work for users.
This PR fixes the code to use `load_module`.