### PR TITLE
Replace `load_module('simple')` to `optunahub.samplers`

### DIFF
--- a/package/samplers/gp_pims/sampler.py
+++ b/package/samplers/gp_pims/sampler.py
@@ -469,10 +469,7 @@ class PI_from_MaxSample(BO):
         return ((self.maximums - mean) / std).ravel()
 
 
-SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
-
-
-class PIMSSampler(SimpleBaseSampler):  # type: ignore
+class PIMSSampler(optunahub.samplers.SimpleBaseSampler):
     def __init__(
         self,
         search_space: dict[str, optuna.distributions.BaseDistribution],

--- a/package/samplers/grey_wolf_optimization/grey_wolf_optimization.py
+++ b/package/samplers/grey_wolf_optimization/grey_wolf_optimization.py
@@ -10,7 +10,7 @@ from optuna.study._study_direction import StudyDirection
 import optunahub
 
 
-class GreyWolfOptimizationSampler(optunahub.load_module("samplers/simple").SimpleBaseSampler):  # type: ignore
+class GreyWolfOptimizationSampler(optunahub.samplers.SimpleBaseSampler):
     def __init__(
         self,
         search_space: dict[str, BaseDistribution] | None = None,

--- a/package/samplers/hebo/sampler.py
+++ b/package/samplers/hebo/sampler.py
@@ -17,10 +17,7 @@ from hebo.design_space.design_space import DesignSpace
 from hebo.optimizers.hebo import HEBO
 
 
-SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
-
-
-class HEBOSampler(SimpleBaseSampler):  # type: ignore
+class HEBOSampler(optunahub.samplers.SimpleBaseSampler):
     def __init__(self, search_space: dict[str, BaseDistribution]) -> None:
         super().__init__(search_space)
         self._hebo = HEBO(self._convert_to_hebo_design_space(search_space))

--- a/package/samplers/nelder_mead/nelder_mead.py
+++ b/package/samplers/nelder_mead/nelder_mead.py
@@ -10,10 +10,7 @@ import optunahub
 from .generate_initial_simplex import generate_initial_simplex
 
 
-SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
-
-
-class NelderMeadSampler(SimpleBaseSampler):  # type: ignore
+class NelderMeadSampler(optunahub.samplers.SimpleBaseSampler):
     """A sampler based on the Nelder-Mead simplex algorithm.
        This algorithm does not support conditional parameters that make a tree-structured search space.
        Sampling for such parameters is delegated to independent_sampler (default: RandomSampler).

--- a/package/samplers/simple/README.md
+++ b/package/samplers/simple/README.md
@@ -20,7 +20,6 @@ import optunahub
 
 class UserDefinedSampler(
     optunahub.samplers.SimpleBaseSampler
-    # optunahub.load_module("samplers/simple").SimpleBaseSampler
 ):
     ...
 ```

--- a/package/samplers/simple/README.md
+++ b/package/samplers/simple/README.md
@@ -7,6 +7,8 @@ optuna_versions: [3.6.1]
 license: MIT License
 ---
 
+`SimpleBaseSampler` has been moved to [`optunahub.samplers`](https://optuna.github.io/optunahub/samplers.html). Please use [`optunahub.samplers.SimpleBaseSampler`](https://optuna.github.io/optunahub/generated/optunahub.samplers.SimpleBaseSampler.html#optunahub.samplers.SimpleBaseSampler) instead of this package.
+
 ## Class or Function Names
 
 - SimpleBaseSampler
@@ -14,8 +16,11 @@ license: MIT License
 ## Example
 
 ```python
+import optunahub
+
 class UserDefinedSampler(
-    optunahub.load_module("samplers/simple").SimpleBaseSampler
+    optunahub.samplers.SimpleBaseSampler
+    # optunahub.load_module("samplers/simple").SimpleBaseSampler
 ):
     ...
 ```

--- a/package/samplers/simple/example.py
+++ b/package/samplers/simple/example.py
@@ -12,7 +12,7 @@ from optuna.trial import FrozenTrial
 import optunahub
 
 
-class UserDefinedSampler(optunahub.load_module("samplers/simple").SimpleBaseSampler):  # type: ignore
+class UserDefinedSampler(optunahub.samplers.SimpleBaseSampler):
     def __init__(self, search_space: dict[str, BaseDistribution] | None = None) -> None:
         super().__init__(search_space)
         self._rng = np.random.RandomState()

--- a/package/samplers/smac_sampler/sampler.py
+++ b/package/samplers/smac_sampler/sampler.py
@@ -34,12 +34,11 @@ from smac.runhistory.enumerations import StatusType
 from smac.scenario import Scenario
 
 
-SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
 _SMAC_INSTANCE_KEY = "smac:instance"
 _SMAC_SEED_KEY = "smac:seed"
 
 
-class SMACSampler(SimpleBaseSampler):  # type: ignore
+class SMACSampler(optunahub.samplers.SimpleBaseSampler):
     """
     A sampler that uses SMAC3 v2.2.0.
 

--- a/package/samplers/whale_optimization/whale_optimization.py
+++ b/package/samplers/whale_optimization/whale_optimization.py
@@ -7,10 +7,7 @@ import optuna
 import optunahub
 
 
-SimpleBaseSampler = optunahub.load_module("samplers/simple").SimpleBaseSampler
-
-
-class WhaleOptimizationSampler(SimpleBaseSampler):  # type: ignore
+class WhaleOptimizationSampler(optunahub.samplers.SimpleBaseSampler):
     def __init__(
         self,
         search_space: dict[str, optuna.distributions.BaseDistribution] | None = None,


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation & Description of the changes

`SimpleBaseSampler` is now provided in `optunahub.samplers`. So, this PR replace old `optunahub.load_module("samplers/simple").SimpleBaseSampler` with `optunahub.samplers.SimpleBaseSampler`.