### PR TITLE
Update README format that allows to provide enough information about APIs

### DIFF
--- a/recipes/002_registration.py
+++ b/recipes/002_registration.py
@@ -80,13 +80,12 @@ Although we recommend you write proper type hints, if you find it difficult to c
 
 - `Abstract <https://github.com/optuna/optunahub-registry/blob/main/template/README.md#abstract>`__ section that describes the summary of your package. It should be a markdown paragraph. This section will help attract potential users to your package.
 
-- `Class or Function Names <https://github.com/optuna/optunahub-registry/blob/main/template/README.md#class-or-function-names>`__ section that describes the classes or functions provided by the package. If you provide multiple classes or functions, you should list them in this section. Note that the section must be a markdown list. If you provide only one class or function, you can simply write the class or function name. Note that the documentation of the classes or functions must be written in their docstrings. If you want to refer to the documentation, please leave the source code link, or write them in the following `Others` section. For example:
+- `APIs <https://github.com/optuna/optunahub-registry/blob/main/template/README.md#apis>`__ section that describes the APIs provided by the package. The documentation format is arbitrary, it is helpful to provide enough information about classes, functions, arguments, etc. to use your package. At least the important class/function names that you implemented should be listed here.
 
   .. code-block:: markdown
 
-      - `DemoSampler1`
-      - `DemoSampler2`
-      - `demo_function1`
+      - `ClassName(*, argment1: argument_type)`
+        - `argument1`: Description of `argument1`.
 
 - An `Installation <https://github.com/optuna/optunahub-registry/blob/main/template/README.md#installation>`__ section that describes how to install the additional dependencies if required. If your package contains ``requirements.txt``, it will be available at ``https://hub.optuna.org/{category}/{your_package_name}/requirements.txt``. Then, the package dependencies can be installed as follows.
 

--- a/template/README.md
+++ b/template/README.md
@@ -61,7 +61,7 @@ More users will take advantage of your package by providing detailed and helpful
   - `popsize`: Population size of the CMA-ES algorithm. If not provided, the population size will be set based on the search space dimensionality. If you have a sufficient evaluation budget, it is recommended to increase the popsize.
   - `seed`: Seed for random number generator.
 
-Note that because of the limitation of the algorithm, only non-conditional numerical parameters are sampled by the MO-CMA-ES algorithm, and categorical parameters and conditional parameters are handled by random sampling.
+Note that because of the limitation of the algorithm, only non-conditional numerical parameters can be sampled by the MO-CMA-ES algorithm, and categorical and conditional parameters are handled by random search.
 
 ## Installation
 

--- a/template/README.md
+++ b/template/README.md
@@ -40,13 +40,28 @@ This section will help attract potential users to your package.
 
 This package provides a sampler based on Gaussian process-based Bayesian optimization. The sampler is highly sample-efficient, so it is suitable for computationally expensive optimization problems with a limited evaluation budget, such as hyperparameter optimization of machine learning algorithms.
 
-## Class or Function Names
+## APIs
 
-Please fill in the class/function names which you implement here.
+Please provide API documentation describing how to use your package's functionalities.
+The documentation format is arbitrary, but at least the important class/function names that you implemented should be listed here.
+More users will take advantage of your package by providing detailed and helpful documentation.
 
 **Example**
 
-- GPSampler
+- `MoCmaSampler(*, search_space: dict[str, BaseDistribution] | None = None, popsize: int | None = None, seed: int | None = None)`
+  - `search_space`: A dictionary containing the search space that defines the parameter space. The keys are the parameter names and the values are [the parameter's distribution](https://optuna.readthedocs.io/en/stable/reference/distributions.html). If the search space is not provided, the sampler will infer the search space dynamically.
+    Example:
+    ```python
+    search_space = {
+        "x": optuna.distributions.FloatDistribution(-5, 5),
+        "y": optuna.distributions.FloatDistribution(-5, 5),
+    }
+    MoCmaSampler(search_space=search_space)
+    ```
+  - `popsize`: Population size of the CMA-ES algorithm. If not provided, the population size will be set based on the search space dimensionality. If you have a sufficient evaluation budget, it is recommended to increase the popsize.
+  - `seed`: Seed for random number generator.
+
+Note that because of the limitation of the algorithm, only non-conditional numerical parameters are sampled by the MO-CMA-ES algorithm, and categorical parameters and conditional parameters are handled by random sampling.
 
 ## Installation
 


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation & Description of the changes

The current format of README cannot provide enough information about APIs.
As a result, users need to read its implementation to understand how to use the package.

This PR changes the format of README that allows to provide enough description about APIs.
