### PR TITLE
Fix assertion in c-TPE

### DIFF
--- a/package/samplers/ctpe/components.py
+++ b/package/samplers/ctpe/components.py
@@ -45,4 +45,4 @@ class WeightFunc:
             weights[:-25] = 1e-12
             return weights
         else:
-            raise AssertionError("Should not reach.")
+            assert False, "Should not reach."

--- a/package/samplers/ctpe/components.py
+++ b/package/samplers/ctpe/components.py
@@ -18,7 +18,7 @@ class GammaFunc:
         elif self._strategy == "sqrt":
             n = int(np.ceil(self._beta * np.sqrt(x)))
         else:
-            assert "Should not reach."
+            raise AssertionError("Should not reach.")
 
         return min(n, 25)
 
@@ -45,4 +45,4 @@ class WeightFunc:
             weights[:-25] = 1e-12
             return weights
         else:
-            assert "Should not reach."
+            raise AssertionError("Should not reach.")

--- a/package/samplers/ctpe/components.py
+++ b/package/samplers/ctpe/components.py
@@ -18,7 +18,7 @@ class GammaFunc:
         elif self._strategy == "sqrt":
             n = int(np.ceil(self._beta * np.sqrt(x)))
         else:
-            raise AssertionError("Should not reach.")
+            assert False, "Should not reach."
 
         return min(n, 25)
 


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
I want to improve c-TPE implementation.

## Description of the changes

<!-- Describe the changes in this PR. -->
There are two `assert "Should not reach."`, which do not work as intended because `bool("Should not reach.") is True`.
I replaced them with `raise AssertionError("Should not reach.")`; it is better than `assert False, "Should not reach."` since python -O removes `assert`s.