### PR TITLE
Remove all-element-non-negative check from user-prior CMA-ES

### DIFF
--- a/package/samplers/user_prior_cmaes/sampler.py
+++ b/package/samplers/user_prior_cmaes/sampler.py
@@ -91,8 +91,6 @@ class UserPriorCmaEsSampler(CmaEsSampler):
             )
         if not np.allclose(cov0, cov0.T):
             raise ValueError("cov0 must be a symmetric matrix.")
-        if np.any(cov0 < 0.0):
-            raise ValueError("All elements in cov0 must be non-negative.")
         if np.any(np.linalg.eigvals(cov0) < 0.0):
             raise ValueError("cov0 must be a semi-positive definite matrix.")
 


### PR DESCRIPTION
As this check is not necessary (and even malicious), I remove this check. I believe this check was simply forgotten to be removed.

## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

This PR is a bug fix.

## Description of the changes

<!-- Describe the changes in this PR. -->

Since the covariance matrix of CMA-ES can contain negative values as well, e.g., think about the case where two variables have negative correlation, I removed the unnecessary check for this.
