### PR TITLE
Fix recursion error upon assersion error

### DIFF
--- a/package/benchmarks/bbob/_bbob.py
+++ b/package/benchmarks/bbob/_bbob.py
@@ -58,9 +58,11 @@ class Problem(optunahub.benchmarks.BaseProblem):
         https://numbbo.github.io/coco-doc/apidocs/cocoex/cocoex.Problem.html
         """
 
+        self._valid_arguments = False
         assert 1 <= function_id <= 24, "function_id must be in [1, 24]"
         assert dimension in [2, 3, 5, 10, 20, 40], "dimension must be in [2, 3, 5, 10, 20, 40]"
         assert 1 <= instance_id <= 110, "instance_id must be in [1, 110]"
+        self._valid_arguments = True
 
         self._problem = ex.Suite("bbob", "", "").get_problem_by_function_dimension_instance(
             function=function_id, dimension=dimension, instance=instance_id
@@ -99,4 +101,7 @@ class Problem(optunahub.benchmarks.BaseProblem):
         return getattr(self._problem, name)
 
     def __del__(self) -> None:
+        if not self._valid_arguments:
+            return
+
         self._problem.free()

--- a/package/benchmarks/bbob_biobj/_bbob_biobj.py
+++ b/package/benchmarks/bbob_biobj/_bbob_biobj.py
@@ -28,9 +28,11 @@ class Problem(optunahub.benchmarks.BaseProblem):
         https://coco-platform.org/testsuites/bbob-biobj/overview.html
         """
 
+        self._valid_arguments = False
         assert 1 <= function_id <= 92, "function_id must be in [1, 92]"
         assert dimension in [2, 3, 5, 10, 20, 40], "dimension must be in [2, 3, 5, 10, 20, 40]"
         assert 1 <= instance_id <= 15, "instance_id must be in [1, 15]"
+        self._valid_arguments = True
 
         # The first 55 functions of the bbob-biobj-ext suite are the same as in the original bbob-biobj test suite
         # to which 37 functions are added. So we always use the bbob-biobj-ext suite for simplicity.
@@ -73,4 +75,7 @@ class Problem(optunahub.benchmarks.BaseProblem):
         return getattr(self._problem, name)
 
     def __del__(self) -> None:
+        if not self._valid_arguments:
+            return
+
         self._problem.free()

--- a/package/benchmarks/bbob_biobj_mixint/_bbob_biobj_mixint.py
+++ b/package/benchmarks/bbob_biobj_mixint/_bbob_biobj_mixint.py
@@ -30,10 +30,12 @@ class Problem(optunahub.benchmarks.BaseProblem):
         https://numbbo.github.io/coco-doc/apidocs/cocoex/cocoex.Problem.html
         """
 
+        self._valid_arguments = False
         assert 1 <= function_id <= 92, "function_id must be in [1, 92]"
         possible_dimensions = [5, 10, 20, 40, 80, 160]
         assert dimension in possible_dimensions, f"dimension must be in {possible_dimensions}."
         assert 1 <= instance_id <= 15, "instance_id must be in [1, 15]"
+        self._valid_arguments = True
 
         self._problem = ex.Suite(
             "bbob-biobj-mixint", "", ""
@@ -80,4 +82,7 @@ class Problem(optunahub.benchmarks.BaseProblem):
         return getattr(self._problem, name)
 
     def __del__(self) -> None:
+        if not self._valid_arguments:
+            return
+
         self._problem.free()

--- a/package/benchmarks/bbob_constrained/_bbob_constrained.py
+++ b/package/benchmarks/bbob_constrained/_bbob_constrained.py
@@ -35,9 +35,11 @@ class Problem(optunahub.benchmarks.ConstrainedMixin, optunahub.benchmarks.BasePr
         https://numbbo.github.io/coco-doc/apidocs/cocoex/cocoex.Problem.html
         """
 
+        self._valid_arguments = False
         assert 1 <= function_id <= 54, "function_id must be in [1, 54]"
         assert dimension in [2, 3, 5, 10, 20, 40], "dimension must be in [2, 3, 5, 10, 20, 40]"
         assert 1 <= instance_id <= 15, "instance_id must be in [1, 15]"
+        self._valid_arguments = True
 
         self._problem = ex.Suite(
             "bbob-constrained", "", ""
@@ -90,4 +92,7 @@ class Problem(optunahub.benchmarks.ConstrainedMixin, optunahub.benchmarks.BasePr
         return getattr(self._problem, name)
 
     def __del__(self) -> None:
+        if not self._valid_arguments:
+            return
+
         self._problem.free()

--- a/package/benchmarks/bbob_largescale/_bbob_largescale.py
+++ b/package/benchmarks/bbob_largescale/_bbob_largescale.py
@@ -58,10 +58,12 @@ class Problem(optunahub.benchmarks.BaseProblem):
         https://numbbo.github.io/coco-doc/apidocs/cocoex/cocoex.Problem.html
         """
 
+        self._valid_arguments = False
         assert 1 <= function_id <= 24, "function_id must be in [1, 24]"
         possible_dimensions = [20, 40, 80, 160, 320, 640]
         assert dimension in possible_dimensions, f"dimension must be in {possible_dimensions}."
         assert 1 <= instance_id <= 15, "instance_id must be in [1, 15]"
+        self._valid_arguments = True
 
         self._problem = ex.Suite(
             "bbob-largescale", "", ""
@@ -102,4 +104,7 @@ class Problem(optunahub.benchmarks.BaseProblem):
         return getattr(self._problem, name)
 
     def __del__(self) -> None:
+        if not self._valid_arguments:
+            return
+
         self._problem.free()

--- a/package/benchmarks/bbob_mixint/_bbob_mixint.py
+++ b/package/benchmarks/bbob_mixint/_bbob_mixint.py
@@ -28,10 +28,12 @@ class Problem(optunahub.benchmarks.BaseProblem):
         https://numbbo.github.io/coco-doc/apidocs/cocoex/cocoex.Problem.html
         """
 
+        self._valid_arguments = False
         assert 1 <= function_id <= 24, "function_id must be in [1, 24]"
         possible_dimensions = [5, 10, 20, 40, 80, 160]
         assert dimension in possible_dimensions, f"dimension must be in {possible_dimensions}."
         assert 1 <= instance_id <= 15, "instance_id must be in [1, 15]"
+        self._valid_arguments = True
 
         self._problem = ex.Suite("bbob-mixint", "", "").get_problem_by_function_dimension_instance(
             function=function_id, dimension=dimension, instance=instance_id
@@ -76,4 +78,7 @@ class Problem(optunahub.benchmarks.BaseProblem):
         return getattr(self._problem, name)
 
     def __del__(self) -> None:
+        if not self._valid_arguments:
+            return
+
         self._problem.free()

--- a/package/benchmarks/bbob_noisy/_bbob_noisy.py
+++ b/package/benchmarks/bbob_noisy/_bbob_noisy.py
@@ -28,9 +28,11 @@ class Problem(optunahub.benchmarks.BaseProblem):
         https://numbbo.github.io/coco-doc/apidocs/cocoex/cocoex.Problem.html
         """
 
+        self._valid_arguments = False
         assert 101 <= function_id <= 130, "function_id must be in [101, 130]"
         assert dimension in [2, 3, 5, 10, 20, 40], "dimension must be in [2, 3, 5, 10, 20, 40]"
         assert 1 <= instance_id <= 15, "instance_id must be in [1, 15]"
+        self._valid_arguments = True
 
         self._problem = ex.Suite("bbob-noisy", "", "").get_problem_by_function_dimension_instance(
             function=function_id, dimension=dimension, instance=instance_id
@@ -69,4 +71,7 @@ class Problem(optunahub.benchmarks.BaseProblem):
         return getattr(self._problem, name)
 
     def __del__(self) -> None:
+        if not self._valid_arguments:
+            return
+
         self._problem.free()


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

When we input an invalid set of arguments to the bbob family, we get the recursion error like this:

```
bbob function_id must be in [1, 24]
Exception ignored in: <function Problem.__del__ at 0x7fd73e0ddd00>
Traceback (most recent call last):
  File "/home/shuhei/pfn-work/optuna-dev/optunahub-registry/./package/benchmarks/bbob/_bbob.py", line 107, in __del__
    self._problem.free()
    ^^^^^^^^^^^^^
  File "/home/shuhei/pfn-work/optuna-dev/optunahub-registry/./package/benchmarks/bbob/_bbob.py", line 101, in __getattr__
    return getattr(self._problem, name)
                   ^^^^^^^^^^^^^
  File "/home/shuhei/pfn-work/optuna-dev/optunahub-registry/./package/benchmarks/bbob/_bbob.py", line 101, in __getattr__
    return getattr(self._problem, name)
                   ^^^^^^^^^^^^^
  File "/home/shuhei/pfn-work/optuna-dev/optunahub-registry/./package/benchmarks/bbob/_bbob.py", line 101, in __getattr__
    return getattr(self._problem, name)
                   ^^^^^^^^^^^^^
  [Previous line repeated 995 more times]
RecursionError: maximum recursion depth exceeded

```

However, this is not really friendly and can be confusing as well.
This PR aims to resolve this issue.
Here is a simple code to verify the new version:

```python
import optuna
import optunahub


names = [
    "bbob", "bbob_biobj", "bbob_biobj_mixint", "bbob_constrained", "bbob_largescale", "bbob_mixint", "bbob_noisy"
]
for name in names:
    try:
        problem = optunahub.load_local_module(f"benchmarks/{name}", registry_root="./package").Problem(
            function_id=0, dimension=2, instance_id=1
        )
    except Exception as e:
        print(name, e)
```