### PR TITLE
Pop size check made robust for multithreaded use of MOEAD sampler

### DIFF
--- a/package/samplers/moead/_elite_population_selection_strategy.py
+++ b/package/samplers/moead/_elite_population_selection_strategy.py
@@ -40,7 +40,7 @@ class MOEAdElitePopulationSelectionStrategy:
             )
             self._compute_neighborhoods(weight_vectors)
 
-        if len(population) == self._population_size:
+        if len(population) < self._population_size * 2:
             return population
 
         self._update_reference_point(study.directions, population)


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

Fixing issue #245 


## Description of the changes

**Solution:** One solution would be to detect remaining "RUNNING" trials and hold-off on any threads getting any samples until the population is complete (a bit like a forced join). This PR provides a simpler solution, which modifies the condition in line 43 of  `_elite_population_selection_strategy.py`, where the check is relaxed from `len(population) == self._population_size` to `len(population) < self._population_size * 2`. This change means that the condition is only FALSE when the population has at least doubled itself, implying an extension has happened with the `parent_population`. a few jobs being completed by some threads beyond the population size will not trigger `_update_neighboring_solutions()`.

**Caveat:** With this solution, there is a higher *tolerance* to the race condition but it is not theoretically impossible to break the search. If a large number of threads race and population_size is small, the condition may become true, even though the population has not been extended. Another more practical caveat, is that any racing threads will still be accounted in  `_update_neighboring_solutions()` which means that the offset "len(population) // 2" will lead to some new trials being compared to other new trials, and not strictly against old trials from the parent population.