### PR TITLE
Fix Incorrect Sampler in `RestartCmaEsSampler` Documentation Example

### DIFF
--- a/package/samplers/restart_cmaes/README.md
+++ b/package/samplers/restart_cmaes/README.md
@@ -65,9 +65,9 @@ def objective(trial):
     return x**2 + y
 
 
-sampler = optuna.samplers.CmaEsSampler()  # CMA-ES without restart (default)
-# sampler = optuna.samplers.CmaEsSampler(restart_strategy="ipop")  # IPOP-CMA-ES
-# sampler = optuna.samplers.CmaEsSampler(restart_strategy="bipop")  # BIPOP-CMA-ES
+sampler = RestartCmaEsSampler()  # CMA-ES without restart (default)
+# sampler = RestartCmaEsSampler(restart_strategy="ipop")  # IPOP-CMA-ES
+# sampler = RestartCmaEsSampler(restart_strategy="bipop")  # BIPOP-CMA-ES
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=20)
 

--- a/package/samplers/restart_cmaes/example.py
+++ b/package/samplers/restart_cmaes/example.py
@@ -12,8 +12,8 @@ def objective(trial: optuna.Trial) -> float:
     return x**2 + y
 
 
-sampler = optuna.samplers.CmaEsSampler()  # CMA-ES without restart (default)
-# sampler = optuna.samplers.CmaEsSampler(restart_strategy="ipop")  # IPOP-CMA-ES
-# sampler = optuna.samplers.CmaEsSampler(restart_strategy="bipop")  # BIPOP-CMA-ES
+sampler = RestartCmaEsSampler()  # CMA-ES without restart (default)
+# sampler = RestartCmaEsSampler(restart_strategy="ipop")  # IPOP-CMA-ES
+# sampler = RestartCmaEsSampler(restart_strategy="bipop")  # BIPOP-CMA-ES
 study = optuna.create_study(sampler=sampler)
 study.optimize(objective, n_trials=20)


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation
The example for `RestartCmaEsSampler` mistakenly uses `CmaEsSampler`, which could cause confusion.

## Description of the changes
- Update the example code to correctly use `RestartCmaEsSampler` instead of `CmaEsSampler`.
- It is confirmed that the example executes correctly and behaves as intended.
