### PR TITLE
Change the URL of optunahub documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Finally, read [`contributor agreements`](#contributor-agreements) and if you agr
 
 ## Tutorial
 
-You can find tutorials to implement a package for the OptunaHub registry in [the OptunaHub registry documentation](https://optuna.github.io/optunahub-registry/).
+You can find tutorials to implement a package for the OptunaHub registry in [Tutorials for Contributors](https://optuna.github.io/optunahub/tutorials_for_contributors.html).
 
 ## Contributor Agreements
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OptunaHub Registry
 
 :link: [**OptunaHub**](https://hub.optuna.org/)
 | :page_with_curl: [**Docs**](https://optuna.github.io/optunahub/)
-| :page_with_curl: [**Tutorials**](https://optuna.github.io/optunahub-registry/)
+| :page_with_curl: [**Tutorials**](https://optuna.github.io/optunahub/tutorials_for_contributors.html)
 | :question: [**OptunaHub FAQ**](https://optuna.github.io/optunahub/faq.html)
 | [**Optuna.org**](https://optuna.org/)
 
@@ -13,7 +13,7 @@ OptunaHub Registry is a registry service for sharing and discovering user-define
 
 See the [OptunaHub Website](https://hub.optuna.org/) for registered packages.
 
-See also the [OptunaHub API documentation](https://optuna.github.io/optunahub/) for the API to use the registry, and the [OptunaHub tutorial](https://optuna.github.io/optunahub-registry/) for how to register and discover packages.
+See also the [OptunaHub API documentation](https://optuna.github.io/optunahub/) for the API to use the registry, and the [tutorials](https://optuna.github.io/optunahub/tutorials_for_contributors.html) for how to register and discover packages.
 
 ## Contribution
 
@@ -37,7 +37,7 @@ When creating your package, please check the following TODO list:
 - Check whether your module works as intended based on the  tips below
 - Fill out `README.md`
 
-For more details, please check [OptunaHub tutorial](https://optuna.github.io/optunahub-registry/).
+For more details, please check [Tutorials for Contributors](https://optuna.github.io/optunahub/tutorials_for_contributors.html).
 
 > [!TIP]
 > The following formatting is a requirement to merge your feature PR:
@@ -60,4 +60,4 @@ For more details, please check [OptunaHub tutorial](https://optuna.github.io/opt
 > )
 > ```
 >
-> For more detail, please check [the tutorial](https://optuna.github.io/optunahub-registry/recipes/005_debugging.html).
+> For more detail, please check [the tutorial](https://optuna.github.io/optunahub/generated/recipes/005_debugging.html).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ docs = [
 [project.urls]
 homepage = "https://hub.optuna.org/"
 repository = "https://github.com/optuna/optunahub-registry"
-documentation = "https://optuna.github.io/optunahub-registry/"
+documentation = "https://optuna.github.io/optunahub/"
 bugtracker = "https://github.com/optuna/optunahub-registry/issues"
 
 [tool.setuptools.packages.find]

--- a/template/README.md
+++ b/template/README.md
@@ -29,7 +29,7 @@ license: "MIT License"
 
 Instruction (Please remove this instruction after you carefully read)
 
-- Please read the [tutorial guide](https://optuna.github.io/optunahub-registry/recipes/001_first.html) to register your feature in OptunaHub. You can find more detailed explanation of the following contents in the tutorial.
+- Please read the [tutorial guide](https://optuna.github.io/optunahub/generated/recipes/001_first.html) to register your feature in OptunaHub. You can find more detailed explanation of the following contents in the tutorial.
 - Looking at [other packages' implementations](https://github.com/optuna/optunahub-registry/tree/main/package) would also be helpful.
 - **Please do not use HTML tags in the `README.md` file. Only markdown is allowed. For security reasons, the HTML tags will be removed when the package is registered on the web page.**
 


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->
I'm now relocating documentation of optunahub-registry to optunahub.
So, changing the link to the docmentation is required.
Related PR:
[https://github.com/optuna/optunahub/pull/91](https://github.com/optuna/optunahub/pull/91)
## Description of the changes
I changed the URL of the documentation in markdown files.
<!-- Describe the changes in this PR. -->

## TODO List towards PR Merge

Please remove this section if this PR is not an addition of a new package.
Otherwise, please check the following TODO list:


- [ ] Copy `./template/` to create your package
- [ ] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [ ] Fill out `README.md` in your package
- [ ] Add import statements of your function or class names to be used in `__init__.py`
- [ ] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [ ] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [ ] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
