### PR TITLE
Fix type annotation and typos in `README.md` for the DTLZ benchmarks

### DIFF
--- a/package/benchmarks/dtlz/README.md
+++ b/package/benchmarks/dtlz/README.md
@@ -15,7 +15,7 @@ This package provides a wrapper of the [optproblems](https://www.simonwessing.de
 
 ### class `Problem(function_id: int, n_objectives: int, dimension: int, k: int, **kwargs: Any)`
 
-- `function_id`: Function ID of the WFG problem in \[1, 9\].
+- `function_id`: Function ID of the DTLZ problem in \[1, 9\].
 - `n_objectives`: Number of objectives.
 - `dimension`: Number of variables.
 - `kwargs`: Arbitrary keyword arguments, please refer to [the optproblems documentation](https://www.simonwessing.de/optproblems/doc/dtlz.html) for more details.

--- a/package/benchmarks/dtlz/README.md
+++ b/package/benchmarks/dtlz/README.md
@@ -15,7 +15,7 @@ This package provides a wrapper of the [optproblems](https://www.simonwessing.de
 
 ### class `Problem(function_id: int, n_objectives: int, dimension: int, k: int, **kwargs: Any)`
 
-- `function_id`: Function ID of the DTLZ problem in \[1, 9\].
+- `function_id`: Function ID of the DTLZ problem in \[1, 7\].
 - `n_objectives`: Number of objectives.
 - `dimension`: Number of variables.
 - `kwargs`: Arbitrary keyword arguments, please refer to [the optproblems documentation](https://www.simonwessing.de/optproblems/doc/dtlz.html) for more details.

--- a/package/benchmarks/dtlz/_dtlz.py
+++ b/package/benchmarks/dtlz/_dtlz.py
@@ -51,7 +51,7 @@ class Problem(optunahub.benchmarks.BaseProblem):
         )
         return [direction] * self._problem.num_objectives
 
-    def evaluate(self, params: dict[str, float]) -> float:
+    def evaluate(self, params: dict[str, float]) -> list[float]:
         """Evaluate the objective functions.
         Args:
             params:


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

Since DTLZ is a multi-objective optimization benchmark, the return type annotation of the `evaluate` method should be `list[float]` rather than `float`.
Also, there are typos in `benchmarks/dtlz/README.md`.

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

## Description of the changes

- Fix the return type annotation of the `evaluate` method.
- Fix typo in `benchmarks/dtlz/README.md`.

> [!NOTE]
> The objective function of the DTLZ benchmark implemented in `optproblems` always returns `list[float]`, even when `n_objectives=1` is specified.

<!-- Describe the changes in this PR. -->

<!--
## TODO List towards PR Merge

Please remove this section if this PR is not an addition of a new package.
Otherwise, please check the following TODO list:


- [ ] Copy `./template/` to create your package
- [ ] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [ ] Fill out `README.md` in your package
- [ ] Add import statements of your function or class names to be used in `__init__.py`
- [ ] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [ ] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [ ] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
-->