### PR TITLE
Fix package installation description in `README.md` for the DTLZ benchmarks

### DIFF
--- a/package/benchmarks/dtlz/README.md
+++ b/package/benchmarks/dtlz/README.md
@@ -42,7 +42,7 @@ The properties defined by [optproblems](https://www.simonwessing.de/optproblems/
 Please install the [optproblems](https://pypi.org/project/optproblems/) package.
 
 ```shell
-pip install -U optproblems
+pip install -U optproblems diversipy
 ```
 
 ## Example


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The DTLZ benchmarks require the `diversipy` package but it's not mentioned in `README.md` (See https://github.com/optuna/optunahub-registry/blob/main/package/benchmarks/dtlz/requirements.txt).

## Description of the changes

Adding `diversipy` in `README.md`.

<!-- Describe the changes in this PR. -->