### PR TITLE
Add robust param API to CARBO

### DIFF
--- a/package/samplers/carbo/_optim.py
+++ b/package/samplers/carbo/_optim.py
@@ -71,7 +71,7 @@ def suggest_by_carbo(
     n_local_search: int,
     local_radius: float,
     tol: float = 1e-4,
-) -> tuple[np.ndarray, float]:
+) -> tuple[np.ndarray, np.ndarray, float]:
     assert best_params is None or len(best_params.shape) == 1, best_params
     dim = len(gpr.length_scales)
     if best_params is not None:
@@ -106,4 +106,4 @@ def suggest_by_carbo(
     )
     assert isinstance(robust_x_local, np.ndarray)
     bounds = _create_bounds(robust_x_local, local_radius)
-    return _gradient_descent(lcb_acqf, robust_x_local, bounds, tol=tol)
+    return robust_x_local, *_gradient_descent(lcb_acqf, robust_x_local, bounds, tol=tol)

--- a/package/samplers/carbo/sampler.py
+++ b/package/samplers/carbo/sampler.py
@@ -30,7 +30,8 @@ if TYPE_CHECKING:
 
 EPS = 1e-10
 DEFAULT_MINIMUM_NOISE_VAR = 1e-6
-_BEST_ACQF_KEY = "best_acqf_val"
+_WORST_ROBUST_ACQF_KEY = "worst_robust_acqf_val"
+_ROBUST_PARAMS_KEY = "robust_params"
 
 
 def _standardize_values(values: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -190,11 +191,13 @@ class CARBOSampler(BaseSampler):
                 for cache, c_train in zip(_cache_list, C_train.T)
             ]
         if len(trials):
-            warmstart_index = [t.number for t in trials].index(self.get_best_trial(study).number)
+            warmstart_index = np.argmax(
+                [t.system_attrs.get(_WORST_ROBUST_ACQF_KEY, -np.inf) for t in trials]
+            )
         else:
             warmstart_index = None
         best_params = None if warmstart_index is None else X_train[warmstart_index].numpy()
-        found_best_params, best_acqf_val = suggest_by_carbo(
+        robust_params, worst_robust_params, worst_robust_acqf_val = suggest_by_carbo(
             gpr=gpr,
             constraints_gpr_list=constraints_gpr_list,
             constraints_threshold_list=constraints_threshold_list,
@@ -205,12 +208,23 @@ class CARBOSampler(BaseSampler):
             n_local_search=self._n_local_search,
             local_radius=self._local_ratio / 2,
         )
-        study._storage.set_trial_system_attr(trial._trial_id, _BEST_ACQF_KEY, best_acqf_val)
         lows, highs, is_log = _get_dist_info_as_arrays(search_space)
+        robust_ext_params = {
+            name: float(param_value)
+            for name, param_value in zip(
+                search_space, unnormalize_params(robust_params[None], is_log, lows, highs)[0]
+            )
+        }
+        study._storage.set_trial_system_attr(
+            trial._trial_id, _WORST_ROBUST_ACQF_KEY, worst_robust_acqf_val
+        )
+        study._storage.set_trial_system_attr(
+            trial._trial_id, _ROBUST_PARAMS_KEY, robust_ext_params
+        )
         return {
             name: float(param_value)
             for name, param_value in zip(
-                search_space, unnormalize_params(found_best_params[None], is_log, lows, highs)[0]
+                search_space, unnormalize_params(worst_robust_params[None], is_log, lows, highs)[0]
             )
         }
 
@@ -235,7 +249,7 @@ class CARBOSampler(BaseSampler):
 
         return search_space
 
-    def get_best_trial(self, study: Study) -> FrozenTrial:
+    def get_robust_params(self, study: Study) -> dict[str, Any]:
         complete_trials = study._get_trials(
             deepcopy=False, states=(TrialState.COMPLETE,), use_cache=False
         )
@@ -243,9 +257,9 @@ class CARBOSampler(BaseSampler):
             raise ValueError("No complete trials found in the study.")
 
         best_idx = np.argmax(
-            [t.system_attrs.get(_BEST_ACQF_KEY, -np.inf) for t in complete_trials]
+            [t.system_attrs.get(_WORST_ROBUST_ACQF_KEY, -np.inf) for t in complete_trials]
         )
-        return complete_trials[best_idx]
+        return complete_trials[best_idx].system_attrs[_ROBUST_PARAMS_KEY]
 
     def sample_independent(
         self,


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.


## Changes
- See `sampler.get_robust_params(study)` below

```python
import numpy as np
import optuna
import optunahub


def numpy_objective(X: np.ndarray) -> np.ndarray:
    C = np.asarray([[2.0, -12.2, 21.2, -6.4, -4.7, 6.2], [1.0, -11, 43.3, -74.8, 56.9, -10]])
    X_poly = np.zeros_like(X)
    for i in range(C.shape[1]):
        X_poly = X * (X_poly + C[:, i])
    X0X1 = X[..., 0] * X[..., 1]
    out = np.sum(X_poly, axis=-1)
    out += X0X1 * (-4.1 - 0.1 * X0X1 + 0.4 * X[..., 0] + 0.4 * X[..., 1])
    return out


def constraint_func0(X: np.ndarray) -> np.ndarray:
    return (X[..., 0] - 1.5)**4 + (X[..., 1] - 1.5)**4 - 10.125


def constraint_func1(X: np.ndarray) -> np.ndarray:
    return (X[..., 0] - 2.5)**3 - (X[..., 1] + 1.5)**3 + 15.75


def objective(trial: optuna.Trial) -> float:
    x = trial.suggest_float("x", -1, 4)
    y = trial.suggest_float("y", -1, 4)
    X = np.array([x, y])
    f = numpy_objective(X).item()
    c0 = constraint_func0(X).item()
    c1 = constraint_func1(X).item()
    trial.set_user_attr("constraints", (c0, c1))
    return f


def constraints(trial: optuna.trial.FrozenTrial) -> tuple[float, float]:
    return trial.user_attrs["constraints"]


CARBOSampler = optunahub.load_local_module("samplers/carbo", registry_root="./package").CARBOSampler
sampler = CARBOSampler(seed=0, constraints_func=constraints)
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=50)
print(sampler.get_robust_params(study))

```