### PR TITLE
Support group parameter for custom TPE sampler

### DIFF
--- a/package/samplers/tpe_tutorial/sampler.py
+++ b/package/samplers/tpe_tutorial/sampler.py
@@ -33,6 +33,7 @@ class CustomizableTPESampler(TPESampler):
         gamma_beta: float = 0.15,
         weight_strategy: str = "EI",
         bandwidth_strategy: str = "hyperopt",
+        group: bool = True,
     ):
         gamma = GammaFunc(strategy=gamma_strategy, beta=gamma_beta)
         weights = WeightFunc(strategy=weight_strategy)
@@ -48,6 +49,7 @@ class CustomizableTPESampler(TPESampler):
             weights=weights,
             seed=seed,
             multivariate=multivariate,
+            group=group,
         )
         self._parzen_estimator_cls = _CustomizableParzenEstimator
         self._parzen_estimator_parameters = _CustomizableParzenEstimatorParameters(


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

The CustomizableTPESampler inherits from the TPESampler but does not support the group parameter. Since the group parameter helps optimize complex search spaces, it would be helpful to support this keyword argument.

## Description of the changes

<!-- Describe the changes in this PR. -->

Added the group keyword argument and passed it to the parent class TPESampler.