### PR TITLE
Add directions to HPOLib, HPOBench, NASBench

### DIFF
--- a/package/benchmarks/hpobench_nn/README.md
+++ b/package/benchmarks/hpobench_nn/README.md
@@ -64,7 +64,7 @@ import optunahub
 
 hpobench = optunahub.load_module("benchmarks/hpobench_nn")
 problem = hpobench.Problem(dataset_id=0)
-study = optuna.create_study()
+study = optuna.create_study(directions=problem.directions)
 study.optimize(problem, n_trials=30)
 print(study.best_trial)
 

--- a/package/benchmarks/hpobench_nn/example.py
+++ b/package/benchmarks/hpobench_nn/example.py
@@ -6,6 +6,6 @@ import optunahub
 
 hpobench = optunahub.load_module("benchmarks/hpobench_nn")
 problem = hpobench.Problem(dataset_id=0)
-study = optuna.create_study()
+study = optuna.create_study(directions=problem.directions)
 study.optimize(problem, n_trials=30)
 print(study.best_trial)

--- a/package/benchmarks/hpolib/README.md
+++ b/package/benchmarks/hpolib/README.md
@@ -64,7 +64,7 @@ import optunahub
 
 hpobench = optunahub.load_module("benchmarks/hpolib")
 problem = hpobench.Problem(dataset_id=0)
-study = optuna.create_study()
+study = optuna.create_study(directions=problem.directions)
 study.optimize(problem, n_trials=30)
 print(study.best_trial)
 

--- a/package/benchmarks/hpolib/example.py
+++ b/package/benchmarks/hpolib/example.py
@@ -6,6 +6,6 @@ import optunahub
 
 hpobench = optunahub.load_module("benchmarks/hpolib")
 problem = hpobench.Problem(dataset_id=0)
-study = optuna.create_study()
+study = optuna.create_study(directions=problem.directions)
 study.optimize(problem, n_trials=30)
 print(study.best_trial)

--- a/package/benchmarks/nasbench201/README.md
+++ b/package/benchmarks/nasbench201/README.md
@@ -66,7 +66,7 @@ import optunahub
 
 hpobench = optunahub.load_module("benchmarks/nasbench201")
 problem = hpobench.Problem(dataset_id=0)
-study = optuna.create_study()
+study = optuna.create_study(directions=problem.directions)
 study.optimize(problem, n_trials=30)
 print(study.best_trial)
 

--- a/package/benchmarks/nasbench201/example.py
+++ b/package/benchmarks/nasbench201/example.py
@@ -6,6 +6,6 @@ import optunahub
 
 hpobench = optunahub.load_module("benchmarks/nasbench201")
 problem = hpobench.Problem(dataset_id=0)
-study = optuna.create_study()
+study = optuna.create_study(directions=problem.directions)
 study.optimize(problem, n_trials=30)
 print(study.best_trial)


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation & Description of the changes

Add directions for running benchmarks properly.
For example, hpobench_nn is a maximization problem.

```python
import optunahub


hpobench = optunahub.load_module("benchmarks/hpobench_nn")
problem = hpobench.Problem(dataset_id=6)
print(problem.metric_names)
print(problem.directions)
```

output
```
['val_acc']
[<StudyDirection.MAXIMIZE: 2>]
```