### PR TITLE
PSO: Infer the relative search space automatically

### DIFF
--- a/package/samplers/pso/README.md
+++ b/package/samplers/pso/README.md
@@ -15,6 +15,8 @@ Particle Swarm Optimization (PSO) is a population-based stochastic optimizer ins
 
 > Note: Multi-objective optimization is not supported.
 
+> Note: PSO Sampler cannot process dynamic changes to the search space.
+
 For details on the algorithm, see Kennedy and Eberhart (1995): [Particle Swarm Optimization](https://doi.org/10.1109/ICNN.1995.488968).
 
 ## APIs

--- a/package/samplers/pso/example.py
+++ b/package/samplers/pso/example.py
@@ -7,6 +7,7 @@ import optunahub
 def objective(trial: optuna.Trial) -> float:
     x = trial.suggest_float("x", -10, 10)
     y = trial.suggest_float("y", -10, 10)
+    _ = trial.suggest_categorical("z", ["x", "y"])  # Sampled by RandomSampler
     return x**2 + y**2
 
 
@@ -22,10 +23,6 @@ if test_local:
         package=package_name,
         registry_root="./package",  # Path to the root of the optunahub-registry.
     ).PSOSampler(
-        {
-            "x": optuna.distributions.FloatDistribution(-10, 10),
-            "y": optuna.distributions.FloatDistribution(-10, 10),
-        },
         n_particles=int(n_trials / n_generations),
         inertia=0.5,
         cognitive=1.5,
@@ -34,10 +31,6 @@ if test_local:
 else:
     # This is an example of how to load a sampler from your fork of the optunahub-registry.
     sampler = optunahub.load_module(package=package_name).PSOSampler(
-        {
-            "x": optuna.distributions.FloatDistribution(-10, 10),
-            "y": optuna.distributions.FloatDistribution(-10, 10),
-        },
         n_particles=int(n_trials / n_generations),
         inertia=0.5,
         cognitive=1.5,


### PR DESCRIPTION
## Contributor Agreements

- [x] I agree to the contributor agreements.

## Motivation

It is annyoing to set the search space for a sampler. So I added the infer_relative_search_space method to the PSO Sampler to find numeric distributions automatically and add them to the search space.

## Description of the changes

- Add infer_relative_search_space to the PSO class
- Notify the user that PSO Sampler cannot process dynamic changes to the search space in the README
