### PR TITLE
Fix mypy errors of value_at_risk sampler

### DIFF
--- a/package/samplers/value_at_risk/_gp/acqf.py
+++ b/package/samplers/value_at_risk/_gp/acqf.py
@@ -11,9 +11,10 @@ import numpy as np
 if TYPE_CHECKING:
     from typing import Protocol
 
-    from optuna._gp.gp import GPRegressor
     from optuna._gp.search_space import SearchSpace
     import torch
+
+    from .gp import GPRegressor
 
     class SobolGenerator(Protocol):
         def __call__(self, dim: int, n_samples: int, seed: int | None) -> torch.Tensor:

--- a/package/samplers/value_at_risk/requirements.txt
+++ b/package/samplers/value_at_risk/requirements.txt
@@ -1,2 +1,3 @@
 scipy
 torch
+typing-extensions

--- a/package/samplers/value_at_risk/tests/test_samplers.py
+++ b/package/samplers/value_at_risk/tests/test_samplers.py
@@ -280,8 +280,8 @@ def test_categorical(
 @parametrize_noise_type
 def test_sample_relative_numerical(
     relative_sampler_class: Callable[[], BaseSampler],
-    x_distribution: BaseDistribution,
-    y_distribution: BaseDistribution,
+    x_distribution: FloatDistribution | IntDistribution,
+    y_distribution: FloatDistribution | IntDistribution,
     noise_type: str,
 ) -> None:
     can_x_be_noisy = x_distribution.step is None and not x_distribution.log


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [X] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Fix the following mypy errors of the `value_at_risk` package.

```
package/samplers/value_at_risk/_gp/acqf.py:192: error: "GPRegressor" has no attribute "joint_posterior"  [attr-defined]
package/samplers/value_at_risk/sampler.py:126: error: Incompatible types in assignment (expression has type "Callable[[optuna._gp.gp.GPRegressor], Tensor]", variable has type "Callable[[value_at_risk._gp.gp.GPRegressor], Tensor]")  [assignment]
package/samplers/value_at_risk/sampler.py:183: error: Argument 1 to "optimize_acqf_mixed" has incompatible type "value_at_risk._gp.acqf.BaseAcquisitionFunc"; expected "optuna._gp.acqf.BaseAcquisitionFunc"  [arg-type]
package/samplers/value_at_risk/sampler.py:286: error: Argument "gpr" to "ValueAtRisk" has incompatible type "value_at_risk._gp.gp.GPRegressor"; expected "optuna._gp.gp.GPRegressor"  [arg-type]
package/samplers/value_at_risk/sampler.py:297: error: Argument "gpr" to "ConstrainedLogValueAtRisk" has incompatible type "value_at_risk._gp.gp.GPRegressor"; expected "optuna._gp.gp.GPRegressor"  [arg-type]
package/samplers/value_at_risk/sampler.py:299: error: Argument "constraints_gpr_list" to "ConstrainedLogValueAtRisk" has incompatible type "list[value_at_risk._gp.gp.GPRegressor]"; expected "list[optuna._gp.gp.GPRegressor]"  [arg-type]
package/samplers/value_at_risk/sampler.py:307: error: Argument 11 to "ConstrainedLogValueAtRisk" has incompatible type "**dict[str, Tensor]"; expected "float"  [arg-type]
package/samplers/value_at_risk/tests/test_samplers.py:12: error: Cannot find implementation or library stub for module named "_pytest.fixtures"  [import-not-found]
package/samplers/value_at_risk/tests/test_samplers.py:13: error: Cannot find implementation or library stub for module named "_pytest.mark.structures"  [import-not-found]
package/samplers/value_at_risk/tests/test_samplers.py:13: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
package/samplers/value_at_risk/tests/test_samplers.py:28: error: Cannot find implementation or library stub for module named "pytest"  [import-not-found]
package/samplers/value_at_risk/tests/test_samplers.py:287: error: "BaseDistribution" has no attribute "step"  [attr-defined]
package/samplers/value_at_risk/tests/test_samplers.py:287: error: "BaseDistribution" has no attribute "log"  [attr-defined]
package/samplers/value_at_risk/tests/test_samplers.py:288: error: "BaseDistribution" has no attribute "step"  [attr-defined]
package/samplers/value_at_risk/tests/test_samplers.py:288: error: "BaseDistribution" has no attribute "log"  [attr-defined]
Found 14 errors in 3 files (checked 7 source files)
```

Regarding errors related to `GPRegressor` and `BaseAcquisitionFunc`, this fix is merely an ad hoc suppression of errors using `cast`.  To fix the problem fundamentally, we have to decide whether to use Optuna's classes or our own versions.

## Description of the changes

<!-- Describe the changes in this PR. -->

## TODO List towards PR Merge

Please remove this section if this PR is not an addition of a new package.
Otherwise, please check the following TODO list:


- [ ] Copy `./template/` to create your package
- [ ] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [ ] Fill out `README.md` in your package
- [ ] Add import statements of your function or class names to be used in `__init__.py`
- [ ] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [ ] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [ ] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
