### PR TITLE
Extend RobustGPSampler to handle environmental disturbance

### DIFF
--- a/package/samplers/value_at_risk/sampler.py
+++ b/package/samplers/value_at_risk/sampler.py
@@ -101,6 +101,10 @@ class RobustGPSampler(BaseSampler):
             The input noise standard deviations for each parameter. For example, when
             `{"x": 0.1, "y": 0.2}` is given, the sampler assumes that the input noise of `x` and
             `y` follows `N(0, 0.1**2)` and `N(0, 0.2**2)`, respectively.
+        const_noisy_param_names:
+            The list of parameters determined externally rather than being decision variables.
+            For these parameters, `suggest_float` samples random values instead of searching
+            values that optimize the objective function.
     """
 
     def __init__(


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [X] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

`RobustGPSampler` already handles cases where noise is added to the decision variables (for example, product dimensions typically do not match the specified values exactly, but vary within the machining accuracy of the manufacturing machines).

However, such variation are not always incidental to the decision variables. For example, the behavior of a chemical engineering process may depend on the outside temperature, which cannot be freely determined.

This PR extends `RobustGPSampler` to handle such cases, by introducing the notion of *constant noisy parameter*.

For example, if the standard outdoor temperature is C but you want to find a robust solution for variations within the range of ±ε, the user can write it as follows:

```python
def objective(trial: optuna.Trial) -> float:
   x = trial.suggest_float("x", ...)
   outside_temperature = trial.suggest_float("outside_temperature", C-ε, C+ε)
   return f(x, outside_temperature)

sampler = RobustGPSampler(..., const_noisy_param_names=["outside_temperature"])
study = optuna.create_study(direction="minimize", sampler=sampler)
study.optimize(objective, ...)

robust_params = sampler.get_robust_params(study)
```

Here,

- `trial.suggest_float` returns a randomly sampled value within the range [C-ε, C+ε] instead of a value that aims to optimize the objective function.
- `sampler.get_robust_params` returns the optimal robust parameter under `outside_temperature`=C. (Fluctuations in `outside_temperature` are accounted for by the acquisition functions which consider nearby points on the GP models).

@nabenabe0928 designed this API and made the initial implementation, and I took over the rest of the implementation.

This API design lacks consistency in the following aspects between decision variables (e.g. dimentions of products) and non-decision variables (e.g. outside temperature), but we plan to address this issue separately in the future.

- For decision variables, we need to specify a nominal range in `suggest_float`, and it returns nominal values unaffected by disturbances.
- For non-decision variables, we have to specify a range accounting for variation, and it returns values after applying disturbances.

## Description of the changes

<!-- Describe the changes in this PR. -->

## TODO List towards PR Merge

Please remove this section if this PR is not an addition of a new package.
Otherwise, please check the following TODO list:


- [ ] Copy `./template/` to create your package
- [ ] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [ ] Fill out `README.md` in your package
- [ ] Add import statements of your function or class names to be used in `__init__.py`
- [ ] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [ ] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [ ] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
