### PR TITLE
Fix NameError and AttributeError of value_at_risk sampler

### DIFF
--- a/package/samplers/value_at_risk/sampler.py
+++ b/package/samplers/value_at_risk/sampler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
@@ -11,6 +12,7 @@ from optuna._experimental import warn_experimental_argument
 from optuna._gp import optim_mixed
 from optuna._gp import prior
 from optuna._gp import search_space as gp_search_space
+import optuna._gp.acqf
 from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.samplers._base import _INDEPENDENT_SAMPLING_WARNING_TEMPLATE
 from optuna.samplers._base import _process_constraints_after_trial
@@ -23,7 +25,6 @@ from typing_extensions import NotRequired
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from collections.abc import Sequence
 
     from optuna.distributions import BaseDistribution


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [X] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Sorry, my previous PR #320 has bugs that causes the following runtime errors.

- `NameError: name 'Callable' is not defined. Did you mean: 'callable'?`
  - `Callable` is used in `cast(Callable[[gp.GPRegressor], torch.Tensor], ...)`, but is imported only during type checking.
- `AttributeError: module 'optuna._gp' has no attribute 'acqf'`
  - `optuna._gp.acqf` is used in `cast(optuna._gp.acqf.BaseAcquisitionFunc, acqf)` and it seems we need to import `optuna._gp.acqf` explicitly.

## Description of the changes

<!-- Describe the changes in this PR. -->

## TODO List towards PR Merge

Please remove this section if this PR is not an addition of a new package.
Otherwise, please check the following TODO list:


- [ ] Copy `./template/` to create your package
- [ ] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [ ] Fill out `README.md` in your package
- [ ] Add import statements of your function or class names to be used in `__init__.py`
- [ ] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [ ] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [ ] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
