### PR TITLE
Bump optuna requirement of value_at_risk sampler to >=4.6

### DIFF
--- a/package/samplers/value_at_risk/README.md
+++ b/package/samplers/value_at_risk/README.md
@@ -3,7 +3,7 @@ author: Shuhei Watanabe
 title: Robust Bayesian Optimization under Input Noise (VaR, Value at Risk)
 description: This sampler searches for parameters robust to input noise
 tags: [sampler, gp, bo]
-optuna_versions: [4.5.0]
+optuna_versions: [4.6.0]
 license: MIT License
 ---
 


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [X] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

@nabenabe0928 san once said that his code (which I included in #328) depends on https://github.com/optuna/optuna/pull/6321 .

Since https://github.com/optuna/optuna/pull/6321 is included in Optuna 4.6.0 and later, I change `value_at_risk` sampler to require Optuna 4.6.0 or later.

I should have included this change in #328. :bow:

## Description of the changes

<!-- Describe the changes in this PR. -->

## TODO List towards PR Merge

Please remove this section if this PR is not an addition of a new package.
Otherwise, please check the following TODO list:


- [ ] Copy `./template/` to create your package
- [ ] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [ ] Fill out `README.md` in your package
- [ ] Add import statements of your function or class names to be used in `__init__.py`
- [ ] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [ ] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [ ] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
