### PR TITLE
Extend RobustGPSampler to allow sampling outside nominal ranges

### DIFF
--- a/package/samplers/value_at_risk/sampler.py
+++ b/package/samplers/value_at_risk/sampler.py
@@ -112,14 +112,14 @@ class RobustGPSampler(BaseSampler):
             nominal value plus added noise and clipping. This option is useful when a user want
             to evaluate the objective function against values with added noise rather than
             nominal values. If this option is enabled, nominal values can be retrieved using
-            `get_nominal_params`.
+            ``get_nominal_params``.
         nominal_ranges:
             An optional dictionary to override nominal ranges for a subset of parameters. If
             a range is specified for a parmaeter, it's nominal value is sampled from the given
-            range instead of the range specified to `suggest_float`. When ``noisy_suggestion``
+            range instead of the range specified to ``suggest_float``. When ``noisy_suggestion``
             is enabled, this option is useful for avoiding clipping: if the noise range is
             +/- eps, specify [L, U] as a nominal range and specify [L-eps, U+eps] for
-            `suggest_float`.
+            ``suggest_float``.
     """
 
     def __init__(


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [X] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Suppose the nominal range of parameter x is [L, U] and the noise range is ±ε. If x is near the bounds, its robustness depends on how the objective function behaves outside the nominal range.

In the worst-case scenario, the objective function value may be favorable near the bounds, but deteriorate sharply when moving outside the bounds. Since we are seeking robust parameters, we should not select such x. But, to learn such behavior of the objective function,  it is necessary to be able to sample values outside the nominal range.

## Description of the changes

<!-- Describe the changes in this PR. -->

To achieve this, the `noisy_suggestion` option is added, which makes`suggest_float()` return values with added noise rather than nominal values.

In this case, since the range specified for `suggest_float()` should be the range after adding noise, the `nominal_ranges` option is added to specify nominal ranges separately.

## TODO List towards PR Merge

Please remove this section if this PR is not an addition of a new package.
Otherwise, please check the following TODO list:


- [ ] Copy `./template/` to create your package
- [ ] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [ ] Fill out `README.md` in your package
- [ ] Add import statements of your function or class names to be used in `__init__.py`
- [ ] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [ ] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [ ] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
