### PR TITLE
feat: add `HeteroscedasticGPSampler` with `noise_func` support

### DIFF
--- a/package/samplers/heteroscedastic_gp/LICENSE
+++ b/package/samplers/heteroscedastic_gp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Rishabh Dewangan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/samplers/heteroscedastic_gp/README.md
+++ b/package/samplers/heteroscedastic_gp/README.md
@@ -1,0 +1,99 @@
+---
+author: Rishabh-git10
+title: Heteroscedastic Gaussian-Process Sampler
+description: A Gaussian Process-based Bayesian Optimization sampler that natively supports heteroscedastic (input-dependent) observation noise to prevent surrogate model corruption.
+tags: [sampler, gaussian-process, bayesian-optimization, heteroscedastic]
+optuna_versions: [3.6.0]
+license: MIT License
+---
+
+## Abstract
+
+Standard Bayesian Optimization assumes homoscedastic (constant) noise across the entire search space. When standard Gaussian Process (GP) models encounter a highly noisy localized region, the Marginal Log-Likelihood optimization is forced to absorb that localized variance into a single global noise parameter. This inflates uncertainty across the entire surrogate model, causing the optimizer to over-explore and waste search budget.
+
+The `HeteroscedasticGPSampler` natively supports input-dependent observation noise. By explicitly passing the known or estimated noise variance of a trial via a user-defined `noise_func`, this sampler maps and isolates high-variance regions. This prevents global surrogate corruption, allowing the acquisition function to maintain sharp exploitation in the clean regions of the search space.
+
+This mirrors the architectural capability of advanced frameworks like BoTorch (via `train_Yvar`), bringing robust, noise-aware Bayesian Optimization natively to Optuna.
+
+## Performance
+
+When evaluated on the Branin-Hoo function injected with input-dependent variance, the `HeteroscedasticGPSampler` significantly reduces median regret compared to the standard `GPSampler`. Explicitly mapping the noise variance allows the surrogate model to avoid over-exploring locally noisy regions, accelerating convergence on the true optimum.
+
+## APIs
+
+- `HeteroscedasticGPSampler(*, seed: int | None = None, independent_sampler: BaseSampler | None = None, n_startup_trials: int = 10, deterministic_objective: bool = False, constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None, noise_func: Callable[[FrozenTrial], float | Sequence[float]] | None = None, warn_independent_sampling: bool = True)`
+  - `noise_func`: An optional function that computes the observation noise variance for a trial. It must take a `optuna.trial.FrozenTrial` and return a `float` (for single-objective optimization) or a sequence of `float`s (for multi-objective optimization). The returned value must be the **variance** of the noise, not the standard deviation. If not provided, the sampler behaves identically to the standard `GPSampler`.
+  - `constraints_func`: An optional function that computes the objective constraints, returning a sequence of floats where values `<= 0` are considered feasible.
+  - `deterministic_objective`: Whether the objective function is deterministic. If `True`, the sampler fixes the noise variance of the surrogate model to the minimum value.
+  - `n_startup_trials`: Number of initial trials evaluated using the `independent_sampler` (default is RandomSearch) before the GP model starts generating suggestions.
+
+## Installation
+
+This package relies on the core dependencies of Optuna's native GP module. OptunaHub will automatically resolve the `requirements.txt` when loaded, or you can install them manually:
+
+```shell
+pip install scipy torch
+```
+
+## Example
+
+To use this sampler, define a `noise_func` that accepts a completed `FrozenTrial` and returns the variance of the observation noise.
+
+```python
+import optuna
+import optunahub
+import numpy as np
+
+
+def objective(trial: optuna.Trial) -> float:
+    x = trial.suggest_float("x", -5.0, 5.0)
+    
+    # Noise variance is a known function of the input
+    noise_variance = 0.1 * np.exp(abs(x))
+    
+    # Log the variance so it can be retrieved by the sampler
+    trial.set_user_attr("variance", noise_variance)
+    
+    true_mean = x**2
+    return true_mean + np.random.normal(0, np.sqrt(noise_variance))
+
+
+def my_noise_func(trial: optuna.trial.FrozenTrial) -> float:
+    # Retrieve the variance logged during the objective evaluation
+    return trial.user_attrs.get("variance", 1e-5)
+
+
+if __name__ == "__main__":
+    module = optunahub.load_module("samplers/heteroscedastic_gp")
+    HeteroscedasticGPSampler = module.HeteroscedasticGPSampler
+
+    study = optuna.create_study(
+        direction="minimize",
+        sampler=HeteroscedasticGPSampler(
+            noise_func=my_noise_func,
+            n_startup_trials=10,
+        )
+    )
+    study.optimize(objective, n_trials=50)
+
+    print(f"Best value: {study.best_value}")
+    print(f"Best params: {study.best_params}")
+```
+
+## Others
+
+### Supported Features
+
+- Single-Objective Optimization: (LogEI)
+
+- Multi-Objective Optimization: (LogEHVI) - Return a list of variances from `noise_func`.
+
+- Constrained Optimization: Fully compatible with `constraints_func`.
+
+- Deterministic Optimization: Set `deterministic_objective=True`.
+
+## Reference
+
+- Makarova, A., Aschenbrenner, M., Fiducioso, M., Krause, A. (2021). Risk-averse Heteroscedastic Bayesian Optimization. Advances in Neural Information Processing Systems (NeurIPS).
+- Rasmussen, C. E., & Williams, C. K. I. (2006). Gaussian Processes for Machine Learning. Chapter 9: Incorporating Explicit Noise Models.
+- Architecture Discussion and Context: [optuna/optuna#6457](https://github.com/optuna/optuna/issues/6457)

--- a/package/samplers/heteroscedastic_gp/__init__.py
+++ b/package/samplers/heteroscedastic_gp/__init__.py
@@ -1,0 +1,4 @@
+from ._sampler import HeteroscedasticGPSampler
+
+
+__all__ = ["HeteroscedasticGPSampler"]

--- a/package/samplers/heteroscedastic_gp/_gp.py
+++ b/package/samplers/heteroscedastic_gp/_gp.py
@@ -1,0 +1,397 @@
+"""Notations in this Gaussian process implementation
+
+X_train: Observed parameter values with the shape of (len(trials), len(params)).
+y_train: Observed objective values with the shape of (len(trials), ).
+x: (Possibly batched) parameter value(s) to evaluate with the shape of (..., len(params)).
+cov_fX_fX: Kernel matrix X = V[f(X)] with the shape of (len(trials), len(trials)).
+cov_fx_fX: Kernel matrix Cov[f(x), f(X)] with the shape of (..., len(trials)).
+cov_fx_fx: Kernel scalar value x = V[f(x)]. This value is constant for the Matern 5/2 kernel.
+cov_Y_Y_inv:
+    The inverse of the covariance matrix (V[f(X) + noise_var])^-1 with the shape of
+    (len(trials), len(trials)).
+cov_Y_Y_inv_Y: `cov_Y_Y_inv @ y` with the shape of (len(trials), ).
+max_Y: The maximum of Y (Note that we transform the objective values such that it is maximized.)
+sqd: The squared differences of each dimension between two points.
+is_categorical:
+    A boolean array with the shape of (len(params), ). If is_categorical[i] is True, the i-th
+    parameter is categorical.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+from typing import TYPE_CHECKING
+
+import numpy as np
+from optuna._gp.scipy_blas_thread_patch import single_blas_thread_if_scipy_v1_15_or_newer
+from optuna._warnings import optuna_warn
+from optuna.logging import get_logger
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import scipy
+    import torch
+else:
+    from optuna._imports import _LazyImport
+
+    scipy = _LazyImport("scipy")
+    torch = _LazyImport("torch")
+
+logger = get_logger(__name__)
+
+
+def warn_and_convert_inf(values: np.ndarray) -> np.ndarray:
+    is_values_finite = np.isfinite(values)
+    if np.all(is_values_finite):
+        return values
+
+    optuna_warn("Clip non-finite values to the min/max finite values for GP fittings.")
+    is_any_finite = np.any(is_values_finite, axis=0)
+    # NOTE(nabenabe): values cannot include nan to apply np.clip properly, but Optuna anyways won't
+    # pass nan in values by design.
+    return np.clip(
+        values,
+        np.where(
+            is_any_finite,
+            np.min(np.where(is_values_finite, values, np.inf), axis=0),
+            0.0,
+        ),
+        np.where(
+            is_any_finite,
+            np.max(np.where(is_values_finite, values, -np.inf), axis=0),
+            0.0,
+        ),
+    )
+
+
+class Matern52Kernel(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx: Any, squared_distance: torch.Tensor) -> torch.Tensor:
+        """
+        This method calculates `exp(-sqrt5d) * (1/3 * sqrt5d ** 2 + sqrt5d + 1)` where
+        `sqrt5d = sqrt(5 * squared_distance)`.
+
+        Please note that automatic differentiation by PyTorch does not work well at
+        `squared_distance = 0` due to zero division, so we manually save the derivative, i.e.,
+        `-5/6 * (1 + sqrt5d) * exp(-sqrt5d)`, for the exact derivative calculation.
+
+        Notice that the derivative of this function is taken w.r.t. d**2, but not w.r.t. d.
+        """
+        sqrt5d = torch.sqrt(5 * squared_distance)
+        exp_part = torch.exp(-sqrt5d)
+        val = exp_part * ((5 / 3) * squared_distance + sqrt5d + 1)
+        deriv = (-5 / 6) * (sqrt5d + 1) * exp_part
+        ctx.save_for_backward(deriv)
+        return val
+
+    @staticmethod
+    def backward(ctx: Any, grad: torch.Tensor) -> torch.Tensor:
+        """
+        Let x be squared_distance, f(x) be forward(ctx, x), and g(f) be a provided function, then
+        deriv := df/dx, grad := dg/df, and deriv * grad = df/dx * dg/df = dg/dx.
+        """
+        (deriv,) = ctx.saved_tensors
+        return deriv * grad
+
+
+class GPRegressor:
+    def __init__(
+        self,
+        is_categorical: torch.Tensor,
+        X_train: torch.Tensor,
+        y_train: torch.Tensor,
+        inverse_squared_lengthscales: torch.Tensor,  # (len(params), )
+        kernel_scale: torch.Tensor,  # Scalar
+        noise_var: torch.Tensor,  # Scalar
+        custom_noise_vars: torch.Tensor | None = None,  # (len(trials), ) or None
+    ) -> None:
+        self._is_categorical = is_categorical
+        self._X_train = X_train
+        self._y_train = y_train
+        self._squared_X_diff = (X_train.unsqueeze(-2) - X_train.unsqueeze(-3)).square_()
+        if self._is_categorical.any():
+            self._squared_X_diff[..., self._is_categorical] = (
+                self._squared_X_diff[..., self._is_categorical] > 0.0
+            ).type(torch.float64)
+        self._cov_Y_Y_chol: torch.Tensor | None = None
+        self._cov_Y_Y_inv_Y: torch.Tensor | None = None
+        # TODO(nabenabe): Rename the attributes to private with `_`.
+        self.inverse_squared_lengthscales = inverse_squared_lengthscales
+        self.kernel_scale = kernel_scale
+        self.noise_var = noise_var
+        self.custom_noise_vars = custom_noise_vars
+
+    @property
+    def length_scales(self) -> np.ndarray:
+        return 1.0 / np.sqrt(self.inverse_squared_lengthscales.detach().cpu().numpy())
+
+    def _cache_matrix(self) -> None:
+        assert (
+            self._cov_Y_Y_chol is None and self._cov_Y_Y_inv_Y is None
+        ), "Cannot call cache_matrix more than once."
+        with torch.no_grad():
+            cov_Y_Y = self.kernel().detach().cpu().numpy()
+
+        diag_indices = np.diag_indices(self._X_train.shape[0])
+        cov_Y_Y[diag_indices] += self.noise_var.item()
+        if self.custom_noise_vars is not None:
+            cov_Y_Y[diag_indices] += self.custom_noise_vars.cpu().numpy()
+
+        cov_Y_Y_chol = np.linalg.cholesky(cov_Y_Y)
+        # cov_Y_Y_inv @ y = v --> y = cov_Y_Y @ v --> y = cov_Y_Y_chol @ cov_Y_Y_chol.T @ v
+        # NOTE(nabenabe): Don't use np.linalg.inv because it is too slow und unstable.
+        # cf. https://github.com/optuna/optuna/issues/6230
+        cov_Y_Y_inv_Y = scipy.linalg.solve_triangular(
+            cov_Y_Y_chol.T,
+            scipy.linalg.solve_triangular(cov_Y_Y_chol, self._y_train.cpu().numpy(), lower=True),
+            lower=False,
+        )
+        # NOTE(nabenabe): Here we use NumPy to guarantee the reproducibility from the past.
+        self._cov_Y_Y_chol = torch.from_numpy(cov_Y_Y_chol)
+        self._cov_Y_Y_inv_Y = torch.from_numpy(cov_Y_Y_inv_Y)
+        self.inverse_squared_lengthscales = self.inverse_squared_lengthscales.detach()
+        self.inverse_squared_lengthscales.grad = None
+        self.kernel_scale = self.kernel_scale.detach()
+        self.kernel_scale.grad = None
+        self.noise_var = self.noise_var.detach()
+        self.noise_var.grad = None
+
+    def kernel(
+        self, X1: torch.Tensor | None = None, X2: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        """
+        Return the kernel matrix with the shape of (..., n_A, n_B) given X1 and X2 each with the
+        shapes of (..., n_A, len(params)) and (..., n_B, len(params)).
+
+        If x1 and x2 have the shape of (len(params), ), kernel(x1, x2) is computed as:
+            kernel_scale * Matern52Kernel.apply(
+                sqd(x1, x2) @ inverse_squared_lengthscales
+            )
+        where if x1[i] is continuous, sqd(x1, x2)[i] = (x1[i] - x2[i]) ** 2 and if x1[i] is
+        categorical, sqd(x1, x2)[i] = int(x1[i] != x2[i]).
+        Note that the distance for categorical parameters is the Hamming distance.
+        """
+        if X1 is None:
+            assert X2 is None
+            sqd = self._squared_X_diff
+        else:
+            if X2 is None:
+                X2 = self._X_train
+
+            sqd = (X1 - X2 if X1.ndim == 1 else X1.unsqueeze(-2) - X2.unsqueeze(-3)).square_()
+            if self._is_categorical.any():
+                sqd[..., self._is_categorical] = (sqd[..., self._is_categorical] > 0.0).type(
+                    torch.float64
+                )
+        sqdist = sqd.matmul(self.inverse_squared_lengthscales)
+        return Matern52Kernel.apply(sqdist) * self.kernel_scale  # type: ignore
+
+    def posterior(self, x: torch.Tensor, joint: bool = False) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        This method computes the posterior mean and variance given the points `x` where both mean
+        and variance tensors will have the shape of x.shape[:-1].
+        If ``joint=True``, the joint posterior will be computed.
+
+        The posterior mean and variance are computed as:
+            mean = cov_fx_fX @ inv(cov_fX_fX + noise_var * I) @ y, and
+            var = cov_fx_fx - cov_fx_fX @ inv(cov_fX_fX + noise_var * I) @ cov_fx_fX.T.
+
+        Please note that we clamp the variance to avoid negative values due to numerical errors.
+        """
+        assert (
+            self._cov_Y_Y_chol is not None and self._cov_Y_Y_inv_Y is not None
+        ), "Call cache_matrix before calling posterior."
+        is_single_point = x.ndim == 1
+        x_ = x if not is_single_point else x.unsqueeze(0)
+        mean = torch.linalg.vecdot(cov_fx_fX := self.kernel(x_), self._cov_Y_Y_inv_Y)
+        # K @ inv(C) = V --> K = V @ C --> K = V @ L @ L.T
+        V = torch.linalg.solve_triangular(
+            self._cov_Y_Y_chol,
+            torch.linalg.solve_triangular(self._cov_Y_Y_chol.T, cov_fx_fX, upper=True, left=False),
+            upper=False,
+            left=False,
+        )
+        if joint:
+            assert not is_single_point, "Call posterior with joint=False for a single point."
+            cov_fx_fx = self.kernel(x_, x_)
+            # NOTE(nabenabe): Indeed, var_ here is a covariance matrix.
+            var_ = cov_fx_fx - V.matmul(cov_fx_fX.transpose(-1, -2))
+            var_.diagonal(dim1=-2, dim2=-1).clamp_min_(0.0)
+        else:
+            cov_fx_fx = self.kernel_scale  # kernel(x, x) = kernel_scale
+            var_ = cov_fx_fx - torch.linalg.vecdot(cov_fx_fX, V)
+            var_.clamp_min_(0.0)
+        return (mean.squeeze(0), var_.squeeze(0)) if is_single_point else (mean, var_)
+
+    def marginal_log_likelihood(self) -> torch.Tensor:  # Scalar
+        """
+        This method computes the marginal log-likelihood of the kernel hyperparameters given the
+        training dataset (X, y).
+        Assume that N = len(X) in this method.
+
+        Mathematically, the closed form is given as:
+            -0.5 * log((2*pi)**N * det(C)) - 0.5 * y.T @ inv(C) @ y
+            = -0.5 * log(det(C)) - 0.5 * y.T @ inv(C) @ y + const,
+        where C = cov_Y_Y = cov_fX_fX + noise_var * I and inv(...) is the inverse operator.
+
+        We exploit the full advantages of the Cholesky decomposition (C = L @ L.T) in this method:
+            1. The determinant of a lower triangular matrix is the diagonal product, which can be
+               computed with N flops where log(det(C)) = log(det(L.T @ L)) = 2 * log(det(L)).
+            2. Solving linear system L @ u = y, which yields u = inv(L) @ y, costs N**2 flops.
+        Note that given `u = inv(L) @ y` and `inv(C) = inv(L @ L.T) = inv(L).T @ inv(L)`,
+        y.T @ inv(C) @ y is calculated as (inv(L) @ y) @ (inv(L) @ y).
+
+        In principle, we could invert the matrix C first, but in this case, it costs:
+            1. 1/3*N**3 flops for the determinant of inv(C).
+            2. 2*N**2-N flops to solve C @ alpha = y, which is alpha = inv(C) @ y.
+
+        Since the Cholesky decomposition costs 1/3*N**3 flops and the matrix inversion costs
+        2/3*N**3 flops, the overall cost for the former is 1/3*N**3+N**2+N flops and that for the
+        latter is N**3+2*N**2-N flops.
+        """
+        n_points = self._X_train.shape[0]
+        const = -0.5 * n_points * math.log(2 * math.pi)
+
+        cov_Y_Y = self.kernel() + self.noise_var * torch.eye(n_points, dtype=torch.float64)
+        if self.custom_noise_vars is not None:
+            cov_Y_Y += torch.diag(self.custom_noise_vars)
+
+        L = torch.linalg.cholesky(cov_Y_Y)
+        logdet_part = -L.diagonal().log().sum()
+        inv_L_y = torch.linalg.solve_triangular(L, self._y_train[:, None], upper=False)[:, 0]
+        quad_part = -0.5 * (inv_L_y @ inv_L_y)
+        return logdet_part + const + quad_part
+
+    def _fit_kernel_params(
+        self,
+        log_prior: Callable[[GPRegressor], torch.Tensor],
+        minimum_noise: float,
+        deterministic_objective: bool,
+        gtol: float,
+    ) -> GPRegressor:
+        n_params = self._X_train.shape[1]
+
+        # We apply log transform to enforce the positivity of the kernel parameters.
+        # Note that we cannot just use the constraint because of the numerical unstability
+        # of the marginal log likelihood.
+        # We also enforce the noise parameter to be greater than `minimum_noise` to avoid
+        # pathological behavior of maximum likelihood estimation.
+        initial_raw_params = np.concatenate(
+            [
+                np.log(self.inverse_squared_lengthscales.detach().cpu().numpy()),
+                [
+                    np.log(self.kernel_scale.item()),
+                    # We add 0.01 * minimum_noise to initial noise_var to avoid instability.
+                    np.log(self.noise_var.item() - 0.99 * minimum_noise),
+                ],
+            ]
+        )
+
+        def loss_func(raw_params: np.ndarray) -> tuple[float, np.ndarray]:
+            raw_params_tensor = torch.from_numpy(raw_params).requires_grad_(True)
+            with torch.enable_grad():
+                self.inverse_squared_lengthscales = torch.exp(raw_params_tensor[:n_params])
+                self.kernel_scale = torch.exp(raw_params_tensor[n_params])
+                self.noise_var = (
+                    torch.tensor(minimum_noise, dtype=torch.float64)
+                    if deterministic_objective
+                    else torch.exp(raw_params_tensor[n_params + 1]) + minimum_noise
+                )
+                loss = -self.marginal_log_likelihood() - log_prior(self)
+                loss.backward()  # type: ignore
+                # scipy.minimize requires all the gradients to be zero for termination.
+                raw_noise_var_grad = raw_params_tensor.grad[n_params + 1]  # type: ignore
+                assert not deterministic_objective or raw_noise_var_grad == 0
+            return loss.item(), raw_params_tensor.grad.detach().cpu().numpy()  # type: ignore
+
+        with single_blas_thread_if_scipy_v1_15_or_newer():
+            # jac=True means loss_func returns the gradient for gradient descent.
+            res = scipy.optimize.minimize(
+                # Too small `gtol` causes instability in loss_func optimization.
+                loss_func,
+                initial_raw_params,
+                jac=True,
+                method="l-bfgs-b",
+                options={"gtol": gtol},
+            )
+        if not res.success:
+            raise RuntimeError(f"Optimization failed: {res.message}")
+
+        raw_params_opt_tensor = torch.from_numpy(res.x)
+        self.inverse_squared_lengthscales = torch.exp(raw_params_opt_tensor[:n_params])
+        self.kernel_scale = torch.exp(raw_params_opt_tensor[n_params])
+        self.noise_var = (
+            torch.tensor(minimum_noise, dtype=torch.float64)
+            if deterministic_objective
+            else minimum_noise + torch.exp(raw_params_opt_tensor[n_params + 1])
+        )
+        self._cache_matrix()
+        return self
+
+
+def fit_kernel_params(
+    X: np.ndarray,
+    Y: np.ndarray,
+    is_categorical: np.ndarray,
+    log_prior: Callable[[GPRegressor], torch.Tensor],
+    minimum_noise: float,
+    deterministic_objective: bool,
+    gpr_cache: GPRegressor | None = None,
+    gtol: float = 1e-2,
+    custom_noise_vars: np.ndarray | None = None,
+) -> GPRegressor:
+    default_kernel_params = torch.ones(X.shape[1] + 2, dtype=torch.float64)
+    # TODO: Move this function into a method of `GPRegressor`
+
+    def _default_gpr() -> GPRegressor:
+        return GPRegressor(
+            is_categorical=torch.from_numpy(is_categorical),
+            X_train=torch.from_numpy(X),
+            y_train=torch.from_numpy(Y),
+            inverse_squared_lengthscales=default_kernel_params[:-2].clone(),
+            kernel_scale=default_kernel_params[-2].clone(),
+            noise_var=default_kernel_params[-1].clone(),
+            custom_noise_vars=(
+                torch.from_numpy(custom_noise_vars) if custom_noise_vars is not None else None
+            ),
+        )
+
+    default_gpr_cache = _default_gpr()
+    if gpr_cache is None:
+        gpr_cache = _default_gpr()
+
+    error = None
+    # First try optimizing the kernel params with the provided kernel parameters in gpr_cache,
+    # but if it fails, rerun the optimization with the default kernel parameters above.
+    # This increases the robustness of the optimization.
+    for gpr_cache_to_use in [gpr_cache, default_gpr_cache]:
+        try:
+            return GPRegressor(
+                is_categorical=torch.from_numpy(is_categorical),
+                X_train=torch.from_numpy(X),
+                y_train=torch.from_numpy(Y),
+                inverse_squared_lengthscales=gpr_cache_to_use.inverse_squared_lengthscales,
+                kernel_scale=gpr_cache_to_use.kernel_scale,
+                noise_var=gpr_cache_to_use.noise_var,
+                custom_noise_vars=(
+                    torch.from_numpy(custom_noise_vars) if custom_noise_vars is not None else None
+                ),
+            )._fit_kernel_params(
+                log_prior=log_prior,
+                minimum_noise=minimum_noise,
+                deterministic_objective=deterministic_objective,
+                gtol=gtol,
+            )
+        except RuntimeError as e:
+            error = e
+
+    logger.warning(
+        f"The optimization of kernel parameters failed: \n{error}\n"
+        "The default initial kernel parameters will be used instead."
+    )
+    default_gpr = _default_gpr()
+    default_gpr._cache_matrix()
+    return default_gpr

--- a/package/samplers/heteroscedastic_gp/_sampler.py
+++ b/package/samplers/heteroscedastic_gp/_sampler.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import TYPE_CHECKING
+
+import numpy as np
+import optuna
+from optuna._experimental import experimental_class
+from optuna._experimental import warn_experimental_argument
+from optuna.samplers._base import _CONSTRAINTS_KEY
+from optuna.samplers._base import _INDEPENDENT_SAMPLING_WARNING_TEMPLATE
+from optuna.samplers._base import _process_constraints_after_trial
+from optuna.samplers._base import BaseSampler
+from optuna.samplers._lazy_random_state import LazyRandomState
+from optuna.study import StudyDirection
+from optuna.study._multi_objective import _is_pareto_front
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+    import optuna._gp.acqf as acqf_module
+    import optuna._gp.optim_mixed as optim_mixed
+    import optuna._gp.prior as prior
+    import optuna._gp.search_space as gp_search_space
+    from optuna.distributions import BaseDistribution
+    from optuna.study import Study
+    import torch
+
+    from . import _gp as gp
+else:
+    from optuna._imports import _LazyImport
+
+    torch = _LazyImport("torch")
+    gp_search_space = _LazyImport("optuna._gp.search_space")
+    from . import _gp as gp
+
+    optim_mixed = _LazyImport("optuna._gp.optim_mixed")
+    acqf_module = _LazyImport("optuna._gp.acqf")
+    prior = _LazyImport("optuna._gp.prior")
+
+import logging
+
+
+_logger = logging.getLogger(__name__)
+
+EPS = 1e-10
+
+
+def _standardize_values(
+    values: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    clipped_values = gp.warn_and_convert_inf(values)
+    means = np.mean(clipped_values, axis=0)
+    stds = np.std(clipped_values, axis=0)
+    standardized_values = (clipped_values - means) / np.maximum(EPS, stds)
+    return standardized_values, means, stds
+
+
+@experimental_class("3.6.0")
+class HeteroscedasticGPSampler(BaseSampler):
+    """Sampler using Gaussian process-based Bayesian optimization.
+
+    This sampler fits a Gaussian process (GP) to the objective function and optimizes
+    the acquisition function to suggest the next parameters.
+
+    The current implementation uses Matern kernel with nu=2.5 (twice differentiable) with automatic
+    relevance determination (ARD) for the length scale of each parameter.
+    The hyperparameters of the kernel are obtained by maximizing the marginal log-likelihood of the
+    hyperparameters given the past trials.
+    To prevent overfitting, Gamma prior is introduced for kernel scale and noise variance and
+    a hand-crafted prior is introduced for inverse squared lengthscales.
+
+    As an acquisition function, we use:
+
+    - log expected improvement (logEI) for single-objective optimization,
+    - log expected hypervolume improvement (logEHVI) for Multi-objective optimization, and
+    - the summation of logEI and the logarithm of the feasible probability with the independent
+      assumption of each constraint for (black-box inequality) constrained optimization.
+
+    For further information about these acquisition functions, please refer to the following
+    papers:
+
+    - `Unexpected Improvements to Expected Improvement for Bayesian Optimization
+      <https://arxiv.org/abs/2310.20708>`__
+    - `Differentiable Expected Hypervolume Improvement for Parallel Multi-Objective Bayesian
+      Optimization <https://arxiv.org/abs/2006.05078>`__
+    - `Bayesian Optimization with Inequality Constraints
+      <https://proceedings.mlr.press/v32/gardner14.pdf>`__
+
+    Please also check our articles:
+
+    - `[Optuna v4.5] Gaussian Process-Based Sampler (GPSampler) Can Now Perform Constrained
+      Multi-Objective Optimization <https://medium.com/optuna/optuna-v4-5-81e78d8e077a>`__
+    - `[Optuna v4.2] Gaussian Process-Based Sampler (GPSampler) Can Now Handle Inequality
+      Constraints
+      <https://medium.com/optuna/optuna-v4-2-gaussian-process-based-sampler-can-now-handle-inequality-constraints-a4f68e8ee810>`__
+    - `Introducing Optuna's Native GPSampler
+      <https://medium.com/optuna/introducing-optunas-native-gpsampler-0aa9aa3b4840>`__
+
+    The optimization of the acquisition function is performed via:
+
+    1. Collect the best param from the past trials,
+    2. Collect ``n_preliminary_samples`` points using Quasi-Monte Carlo (QMC) sampling,
+    3. Choose the best point from the collected points,
+    4. Choose ``n_local_search - 2`` points from the collected points using the roulette
+       selection,
+    5. Perform a local search for each chosen point as an initial point, and
+    6. Return the point with the best acquisition function value as the next parameter.
+
+    Decoupled optimizer update with a batched evaluation is employed to perform a batch of local
+    searches simultaneously, specifically speeding up Step 5 above.
+
+    The following paper details the methodology:
+
+    - `Batch Acquisition Function Evaluations and Decouple Optimizer Updates for Faster Bayesian
+      Optimization <https://arxiv.org/abs/2511.13625>`__
+
+    Note that the procedures for non single-objective optimization setups are slightly different
+    from the single-objective version described above, but we omit the descriptions for the others
+    for brevity.
+
+    The local search iteratively optimizes the acquisition function by repeating:
+
+    1. Gradient ascent using l-BFGS-B for continuous parameters, and
+    2. Line search or exhaustive search for each discrete parameter independently.
+
+    The local search is terminated if the routine stops updating the best parameter set or the
+    maximum number of iterations is reached.
+
+    We use line search instead of rounding the results from the continuous optimization since EI
+    typically yields a high value between one grid and its adjacent grid.
+
+    .. note::
+        This sampler requires ``scipy`` and ``torch``.
+        You can install these dependencies with ``pip install scipy torch``.
+
+    Args:
+        seed:
+            Random seed to initialize internal random number generator.
+            Defaults to :obj:`None` (a seed is picked randomly).
+        independent_sampler:
+            Sampler used for initial sampling (for the first ``n_startup_trials`` trials)
+            and for conditional parameters. Defaults to :obj:`None`
+            (a random sampler with the same ``seed`` is used).
+        n_startup_trials:
+            Number of initial trials. Defaults to 10.
+        deterministic_objective:
+            Whether the objective function is deterministic or not.
+            If :obj:`True`, the sampler will fix the noise variance of the surrogate model to
+            the minimum value (slightly above 0 to ensure numerical stability).
+            Defaults to :obj:`False`. Currently, all the objectives will be assume to be
+            deterministic if :obj:`True`.
+        constraints_func:
+            An optional function that computes the objective constraints. It must take a
+            :class:`~optuna.trial.FrozenTrial` and return the constraints. The return value must
+            be a sequence of :obj:`float` s. A value strictly larger than 0 means that a
+            constraints is violated. A value equal to or smaller than 0 is considered feasible.
+            If ``constraints_func`` returns more than one value for a trial, that trial is
+            considered feasible if and only if all values are equal to 0 or smaller.
+
+            The ``constraints_func`` will be evaluated after each successful trial.
+            The function won't be called when trials fail or are pruned, but this behavior is
+            subject to change in future releases.
+        warn_independent_sampling:
+            If this is :obj:`True`, a warning message is emitted when
+            the value of a parameter is sampled by using an independent sampler,
+            meaning that no GP model is used in the sampling.
+            Note that the parameters of the first trial in a study are always sampled
+            via an independent sampler, so no warning messages are emitted in this case.
+    """
+
+    def __init__(
+        self,
+        *,
+        seed: int | None = None,
+        independent_sampler: BaseSampler | None = None,
+        n_startup_trials: int = 10,
+        deterministic_objective: bool = False,
+        constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
+        noise_func: Callable[[FrozenTrial], float | Sequence[float]] | None = None,
+        warn_independent_sampling: bool = True,
+    ) -> None:
+        self._rng = LazyRandomState(seed)
+        self._independent_sampler = independent_sampler or optuna.samplers.RandomSampler(seed=seed)
+        self._intersection_search_space = optuna.search_space.IntersectionSearchSpace()
+        self._n_startup_trials = n_startup_trials
+        self._log_prior: Callable[[gp.GPRegressor], torch.Tensor] = prior.default_log_prior
+        self._minimum_noise: float = prior.DEFAULT_MINIMUM_NOISE_VAR
+        # We cache the kernel parameters for initial values of fitting the next time.
+        # TODO(nabenabe): Make the cache lists system_attrs to make GPSampler stateless.
+        self._gprs_cache_list: list[gp.GPRegressor] | None = None
+        self._constraints_gprs_cache_list: list[gp.GPRegressor] | None = None
+        self._deterministic = deterministic_objective
+        self._constraints_func = constraints_func
+        self._noise_func = noise_func
+        self._warn_independent_sampling = warn_independent_sampling
+
+        if constraints_func is not None:
+            warn_experimental_argument("constraints_func")
+        if noise_func is not None:
+            warn_experimental_argument("noise_func")
+
+        # Control parameters of the acquisition function optimization.
+        self._n_preliminary_samples: int = 2048
+        # NOTE(nabenabe): ehvi in BoTorchSampler uses 20.
+        self._n_local_search = 10
+        self._tol = 1e-4
+
+    def _log_independent_sampling(self, trial: FrozenTrial, param_name: str) -> None:
+        msg = _INDEPENDENT_SAMPLING_WARNING_TEMPLATE.format(
+            param_name=param_name,
+            trial_number=trial.number,
+            independent_sampler_name=self._independent_sampler.__class__.__name__,
+            sampler_name=self.__class__.__name__,
+            fallback_reason="dynamic search space is not supported by GPSampler",
+        )
+        _logger.warning(msg)
+
+    def reseed_rng(self) -> None:
+        self._rng.rng.seed()
+        self._independent_sampler.reseed_rng()
+
+    def infer_relative_search_space(
+        self, study: Study, trial: FrozenTrial
+    ) -> dict[str, BaseDistribution]:
+        search_space = {}
+        for name, distribution in self._intersection_search_space.calculate(study).items():
+            if distribution.single():
+                continue
+            search_space[name] = distribution
+
+        return search_space
+
+    def _optimize_acqf(
+        self, acqf: acqf_module.BaseAcquisitionFunc, best_params: np.ndarray | None
+    ) -> np.ndarray:
+        # Advanced users can override this method to change the optimization algorithm.
+        # However, we do not make any effort to keep backward compatibility between versions.
+        # Particularly, we may remove this function in future refactoring.
+        assert best_params is None or len(best_params.shape) == 2
+        normalized_params, _acqf_val = optim_mixed.optimize_acqf_mixed(
+            acqf,
+            warmstart_normalized_params_array=best_params,
+            n_preliminary_samples=self._n_preliminary_samples,
+            n_local_search=self._n_local_search,
+            tol=self._tol,
+            rng=self._rng.rng,
+        )
+        return normalized_params
+
+    def _get_constraints_acqf_args(
+        self,
+        constraint_vals: np.ndarray,
+        internal_search_space: gp_search_space.SearchSpace,
+        normalized_params: np.ndarray,
+    ) -> tuple[list[gp.GPRegressor], list[float]]:
+        # NOTE(nabenabe): Flip the sign of constraints since they are always to be minimized.
+        standardized_constraint_vals, means, stds = _standardize_values(-constraint_vals)
+        if (
+            self._constraints_gprs_cache_list is not None
+            and len(self._constraints_gprs_cache_list[0].inverse_squared_lengthscales)
+            != internal_search_space.dim
+        ):
+            # Clear cache if the search space changes.
+            self._constraints_gprs_cache_list = None
+
+        is_categorical = internal_search_space.is_categorical
+        constraints_gprs = []
+        constraints_threshold_list = []
+        constraints_threshold_list = (-means / np.maximum(EPS, stds)).tolist()
+        for i, vals in enumerate(standardized_constraint_vals.T):
+            cache = (
+                self._constraints_gprs_cache_list[i]
+                if self._constraints_gprs_cache_list is not None
+                else None
+            )
+            gpr = gp.fit_kernel_params(
+                X=normalized_params,
+                Y=vals,
+                is_categorical=is_categorical,
+                log_prior=self._log_prior,
+                minimum_noise=self._minimum_noise,
+                gpr_cache=cache,
+                deterministic_objective=self._deterministic,
+            )
+            constraints_gprs.append(gpr)
+
+        self._constraints_gprs_cache_list = constraints_gprs
+        return constraints_gprs, constraints_threshold_list
+
+    def _get_best_params_for_multi_objective(
+        self,
+        normalized_params: np.ndarray,
+        standardized_score_vals: np.ndarray,
+    ) -> np.ndarray:
+        pareto_params = normalized_params[
+            _is_pareto_front(-standardized_score_vals, assume_unique_lexsorted=False)
+        ]
+        n_pareto_sols = len(pareto_params)
+        # TODO(nabenabe): Verify the validity of this choice.
+        size = min(self._n_local_search // 2, n_pareto_sols)
+        chosen_indices = self._rng.rng.choice(n_pareto_sols, size=size, replace=False)
+        return pareto_params[chosen_indices]
+
+    def sample_relative(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        search_space: dict[str, BaseDistribution],
+    ) -> dict[str, Any]:
+        if search_space == {}:
+            return {}
+
+        states = (TrialState.COMPLETE,)
+        trials = study._get_trials(deepcopy=False, states=states, use_cache=True)
+
+        if len(trials) < self._n_startup_trials:
+            return {}
+
+        # Force CPU device for all torch operations to avoid issues when
+        # torch.set_default_device("cuda") is set globally (issue #6113).
+        with torch.device("cpu"):
+            return self._sample_relative_impl(study, trials, search_space)
+
+    def _sample_relative_impl(
+        self,
+        study: Study,
+        trials: list[FrozenTrial],
+        search_space: dict[str, BaseDistribution],
+    ) -> dict[str, Any]:
+        internal_search_space = gp_search_space.SearchSpace(search_space)
+        normalized_params = internal_search_space.get_normalized_params(trials)
+
+        _sign = np.array([-1.0 if d == StudyDirection.MINIMIZE else 1.0 for d in study.directions])
+        standardized_score_vals, _, stds = _standardize_values(
+            _sign * np.array([trial.values for trial in trials])
+        )
+
+        n_objectives = standardized_score_vals.shape[-1]
+
+        has_custom_noise = False
+        raw_noise_vars_list = []
+
+        if self._noise_func is not None:
+            for t in trials:
+                val = self._noise_func(t)
+                # Handle single objective (float) or multi-objective (sequence)
+                if isinstance(val, (int, float)):
+                    if val > 0.0:
+                        has_custom_noise = True
+                    raw_noise_vars_list.append([float(val)] * n_objectives)
+                elif isinstance(val, (list, tuple)):
+                    if any(v > 0.0 for v in val):
+                        has_custom_noise = True
+                    raw_noise_vars_list.append(list(val))
+                else:
+                    raise ValueError(
+                        f"noise_func must return a float or a sequence of floats, got {type(val)}."
+                    )
+        if has_custom_noise:
+            raw_noise_vars = np.array(raw_noise_vars_list, dtype=np.float64)
+            scaled_noise_vars = raw_noise_vars / np.maximum(EPS, stds**2)
+        else:
+            scaled_noise_vars = None
+
+        if (
+            self._gprs_cache_list is not None
+            and len(self._gprs_cache_list[0].inverse_squared_lengthscales)
+            != internal_search_space.dim
+        ):
+            self._gprs_cache_list = None
+
+        gprs_list = []
+        n_objectives = standardized_score_vals.shape[-1]
+        is_categorical = internal_search_space.is_categorical
+        for i in range(n_objectives):
+            cache = self._gprs_cache_list[i] if self._gprs_cache_list is not None else None
+            custom_noise = scaled_noise_vars[:, i] if has_custom_noise else None
+            gprs_list.append(
+                gp.fit_kernel_params(
+                    X=normalized_params,
+                    Y=standardized_score_vals[:, i],
+                    is_categorical=is_categorical,
+                    log_prior=self._log_prior,
+                    minimum_noise=self._minimum_noise,
+                    gpr_cache=cache,
+                    deterministic_objective=self._deterministic,
+                    custom_noise_vars=custom_noise,
+                )
+            )
+        self._gprs_cache_list = gprs_list
+
+        best_params: np.ndarray | None
+        acqf: acqf_module.BaseAcquisitionFunc
+        if self._constraints_func is None:
+            if n_objectives == 1:
+                assert len(gprs_list) == 1
+                acqf = acqf_module.LogEI(
+                    gpr=gprs_list[0],
+                    search_space=internal_search_space,
+                    threshold=standardized_score_vals[:, 0].max(),
+                )
+                best_params = normalized_params[np.argmax(standardized_score_vals), np.newaxis]
+            else:
+                acqf = acqf_module.LogEHVI(
+                    gpr_list=gprs_list,
+                    search_space=internal_search_space,
+                    Y_train=torch.from_numpy(standardized_score_vals),
+                    n_qmc_samples=128,  # NOTE(nabenabe): The BoTorch default value.
+                    qmc_seed=self._rng.rng.randint(1 << 30),
+                )
+                best_params = self._get_best_params_for_multi_objective(
+                    normalized_params, standardized_score_vals
+                )
+        else:
+            if n_objectives == 1:
+                assert len(gprs_list) == 1
+                constraint_vals, is_feasible = _get_constraint_vals_and_feasibility(study, trials)
+                y_with_neginf = np.where(is_feasible, standardized_score_vals[:, 0], -np.inf)
+                # TODO(kAIto47802): If all trials are infeasible, the acquisition function
+                # for the objective function can be ignored, so skipping the computation
+                # of gpr can speed up.
+                # TODO(kAIto47802): Consider the case where all trials are feasible.
+                # We can ignore constraints in this case.
+                constr_gpr_list, constr_threshold_list = self._get_constraints_acqf_args(
+                    constraint_vals, internal_search_space, normalized_params
+                )
+                i_opt = np.argmax(y_with_neginf)
+                best_feasible_y = y_with_neginf[i_opt]
+                acqf = acqf_module.ConstrainedLogEI(
+                    gpr=gprs_list[0],
+                    search_space=internal_search_space,
+                    threshold=best_feasible_y,
+                    constraints_gpr_list=constr_gpr_list,
+                    constraints_threshold_list=constr_threshold_list,
+                )
+                assert normalized_params.shape[:-1] == y_with_neginf.shape
+                best_params = (
+                    None if np.isneginf(best_feasible_y) else normalized_params[i_opt, np.newaxis]
+                )
+            else:
+                constraint_vals, is_feasible = _get_constraint_vals_and_feasibility(study, trials)
+                constr_gpr_list, constr_threshold_list = self._get_constraints_acqf_args(
+                    constraint_vals, internal_search_space, normalized_params
+                )
+                is_all_infeasible = not any(is_feasible)
+                acqf = acqf_module.ConstrainedLogEHVI(
+                    gpr_list=gprs_list,
+                    search_space=internal_search_space,
+                    Y_feasible=(
+                        torch.from_numpy(standardized_score_vals[is_feasible])
+                        if not is_all_infeasible
+                        else None
+                    ),
+                    n_qmc_samples=128,  # NOTE(nabenabe): The BoTorch default value.
+                    qmc_seed=self._rng.rng.randint(1 << 30),
+                    constraints_gpr_list=constr_gpr_list,
+                    constraints_threshold_list=constr_threshold_list,
+                )
+                best_params = (
+                    self._get_best_params_for_multi_objective(
+                        normalized_params[is_feasible],
+                        standardized_score_vals[is_feasible],
+                    )
+                    if not is_all_infeasible
+                    else None
+                )
+
+        normalized_param = self._optimize_acqf(acqf, best_params)
+        return internal_search_space.get_unnormalized_param(normalized_param)
+
+    def sample_independent(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        param_name: str,
+        param_distribution: BaseDistribution,
+    ) -> Any:
+        if self._warn_independent_sampling:
+            states = (TrialState.COMPLETE,)
+            complete_trials = study._get_trials(deepcopy=False, states=states, use_cache=True)
+            if len(complete_trials) >= self._n_startup_trials:
+                self._log_independent_sampling(trial, param_name)
+        return self._independent_sampler.sample_independent(
+            study, trial, param_name, param_distribution
+        )
+
+    def before_trial(self, study: Study, trial: FrozenTrial) -> None:
+        self._independent_sampler.before_trial(study, trial)
+
+    def after_trial(
+        self,
+        study: Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Sequence[float] | None,
+    ) -> None:
+        if self._constraints_func is not None:
+            _process_constraints_after_trial(self._constraints_func, study, trial, state)
+        self._independent_sampler.after_trial(study, trial, state, values)
+
+
+def _get_constraint_vals_and_feasibility(
+    study: Study, trials: list[FrozenTrial]
+) -> tuple[np.ndarray, np.ndarray]:
+    _constraint_vals = [
+        study._storage.get_trial_system_attrs(trial._trial_id).get(_CONSTRAINTS_KEY, ())
+        for trial in trials
+    ]
+    if any(len(_constraint_vals[0]) != len(c) for c in _constraint_vals):
+        raise ValueError("The number of constraints must be the same for all trials.")
+
+    constraint_vals = np.array(_constraint_vals)
+    assert len(constraint_vals.shape) == 2, "constraint_vals must be a 2d array."
+    is_feasible = np.all(constraint_vals <= 0, axis=1)
+    assert not isinstance(is_feasible, np.bool_), "MyPy Redefinition for NumPy v2.2.0."
+    return constraint_vals, is_feasible

--- a/package/samplers/heteroscedastic_gp/example.py
+++ b/package/samplers/heteroscedastic_gp/example.py
@@ -7,6 +7,8 @@ across the parameter space and you have an analytical expression or empirical
 estimate of the noise variance for each trial.
 """
 
+from __future__ import annotations
+
 import math
 
 import numpy as np

--- a/package/samplers/heteroscedastic_gp/example.py
+++ b/package/samplers/heteroscedastic_gp/example.py
@@ -1,0 +1,94 @@
+"""
+Example demonstrating HeteroscedasticGPSampler.
+
+This Gaussian process-based sampler natively supports heteroscedastic
+(input-dependent) observation noise. It is useful when evaluation noise varies
+across the parameter space and you have an analytical expression or empirical
+estimate of the noise variance for each trial.
+"""
+
+import math
+
+import numpy as np
+import optuna
+import optunahub
+
+
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+module = optunahub.load_module(package="samplers/heteroscedastic_gp")
+
+HeteroscedasticGPSampler = module.HeteroscedasticGPSampler
+
+
+def branin(x1: float, x2: float) -> float:
+    # Branin-Hoo function
+    a, b, c = 1.0, 5.1 / (4 * math.pi**2), 5.0 / math.pi
+    r, s, t = 6.0, 10.0, 1.0 / (8 * math.pi)
+    return a * (x2 - b * x1**2 + c * x1 - r) ** 2 + s * (1 - t) * math.cos(x1) + s
+
+
+def noisy_branin_objective(trial: optuna.Trial) -> float:
+    # Single-objective Branin with spatially-varying Gaussian noise
+    x1 = trial.suggest_float("x1", -5, 10)
+    x2 = trial.suggest_float("x2", 0, 15)
+    noise_std = 0.1 * (1.0 + abs(x1) / 10 + abs(x2) / 15)
+    return branin(x1, x2) + np.random.normal(0.0, noise_std)
+
+
+def branin_noise_func(trial: optuna.trial.FrozenTrial) -> float:
+    # Return the variance of the observation noise for a single-objective trial
+    x1 = trial.params["x1"]
+    x2 = trial.params["x2"]
+    noise_std = 0.1 * (1.0 + abs(x1) / 10 + abs(x2) / 15)
+    return noise_std**2
+
+
+def multi_obj_noisy(trial: optuna.Trial) -> tuple[float, float]:
+    # Multi-objective function with spatially-varying noise
+    x = trial.suggest_float("x", 0, 1)
+    y = trial.suggest_float("y", 0, 1)
+    noise1_std = 0.05 * (1 + x)
+    noise2_std = 0.05 * (1 + y)
+    f1 = x**2 + np.random.normal(0, noise1_std)
+    f2 = (x - 1) ** 2 + np.random.normal(0, noise2_std)
+    return f1, f2
+
+
+def multi_obj_noise_func(trial: optuna.trial.FrozenTrial) -> list[float]:
+    # Return the per-objective variances as a list
+    x = trial.params["x"]
+    y = trial.params["y"]
+    return [(0.05 * (1 + x)) ** 2, (0.05 * (1 + y)) ** 2]
+
+
+if __name__ == "__main__":
+    print("Running Single-Objective Heteroscedastic Optimization...")
+    sampler = HeteroscedasticGPSampler(
+        seed=42,
+        noise_func=branin_noise_func,
+        n_startup_trials=10,
+    )
+    study = optuna.create_study(direction="minimize", sampler=sampler)
+    study.optimize(noisy_branin_objective, n_trials=50)
+
+    print(f"Best value : {study.best_value:.4f}")
+    print(f"Best params: {study.best_params}\n")
+
+    print("Running Multi-Objective Heteroscedastic Optimization...")
+    mo_sampler = HeteroscedasticGPSampler(
+        seed=42,
+        noise_func=multi_obj_noise_func,
+        n_startup_trials=10,
+    )
+    mo_study = optuna.create_study(
+        directions=["minimize", "minimize"],
+        sampler=mo_sampler,
+    )
+    mo_study.optimize(multi_obj_noisy, n_trials=50)
+
+    pareto = mo_study.best_trials
+    print(f"Number of Pareto-optimal trials: {len(pareto)}")
+    print("Sample Pareto front (first 3):")
+    for t in pareto[:3]:
+        print(f"  params={t.params}, values={[round(v, 4) for v in t.values]}")

--- a/package/samplers/heteroscedastic_gp/requirements.txt
+++ b/package/samplers/heteroscedastic_gp/requirements.txt
@@ -1,0 +1,2 @@
+scipy
+torch


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

Standard Gaussian Process (GP) models assume homoscedastic (constant) noise. When encountering highly noisy localized regions, the surrogate model inflates uncertainty globally, leading to over-exploration. 

As discussed in [optuna/optuna#6457](https://github.com/optuna/optuna/issues/6457), this PR implements a native GP sampler that supports heteroscedastic (input-dependent) observation noise. Moving this to OptunaHub keeps the core Optuna library lean while providing advanced, noise-aware Bayesian Optimization capabilities.

## Description of the changes

This PR adds the `HeteroscedasticGPSampler` under the `samplers/heteroscedastic_gp` directory.

Key implementations:
* **`noise_func` Callback:** Allows users to pass explicit observation noise variance for each trial, isolating high-variance regions.
* **Multi-Objective & Constrained Support:** Fully integrates with `LogEI`, `LogEHVI`, and `constraints_func`.
* **Performance:** Evaluated on the Branin-Hoo function injected with input-dependent variance, demonstrating a reduction in median regret compared to the standard homoscedastic `GPSampler`.


## TODO List towards PR Merge

- [x] Copy `./template/` to create your package
- [x] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [x] Fill out `README.md` in your package
- [x] Add import statements of your function or class names to be used in `__init__.py`
- [x] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [x] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [x] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)