### PR TITLE
docs: clarify terminology distinction from HEBO in `HeteroscedasticGPSampler` README

### DIFF
--- a/package/samplers/heteroscedastic_gp/README.md
+++ b/package/samplers/heteroscedastic_gp/README.md
@@ -15,6 +15,8 @@ The `HeteroscedasticGPSampler` natively supports input-dependent observation noi
 
 This mirrors the architectural capability of advanced frameworks like BoTorch (via `train_Yvar`), bringing robust, noise-aware Bayesian Optimization natively to Optuna.
 
+**Note:** This implementation is distinct from HEBO (Heteroscedastic Evolutionary Bayesian Optimization). While HEBO handles heteroscedasticity by applying non-linear warping to objective values, this sampler allows users to explicitly provide the observation noise variance at each individual data point.
+
 ## Performance
 
 When evaluated on the Branin-Hoo function injected with input-dependent variance, the `HeteroscedasticGPSampler` significantly reduces median regret compared to the standard `GPSampler`. Explicitly mapping the noise variance allows the surrogate model to avoid over-exploring locally noisy regions, accelerating convergence on the true optimum.


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

Following up on [this review comment](https://github.com/optuna/optunahub-registry/pull/355#issuecomment-4275202559) by @nabenabe0928. In the BO community, the term "Heteroscedastic GP" is heavily associated with HEBO. Because HEBO handles heteroscedasticity via non-linear objective warping rather than our point-wise noise tuning approach, this documentation update ensures users do not conflate the two methodologies.

## Description of the changes

Added a "Note" section to the `package/samplers/heteroscedastic_gp/README.md` abstract to explicitly distinguish this implementation from HEBO.

## TODO List towards PR Merge

Please remove this section if this PR is not an addition of a new package.
Otherwise, please check the following TODO list:

- [ ] Copy `./template/` to create your package
- [ ] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [x] Fill out `README.md` in your package
- [ ] Add import statements of your function or class names to be used in `__init__.py`
- [ ] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [x] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [ ] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)