### PR TITLE
feat(visualization): Add curved parallel coordinate plot using Pchip interpolation

### DIFF
--- a/package/visualization/plot_curved_parallel_coordinate/LICENSE
+++ b/package/visualization/plot_curved_parallel_coordinate/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Rishabh Dewangan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/visualization/plot_curved_parallel_coordinate/README.md
+++ b/package/visualization/plot_curved_parallel_coordinate/README.md
@@ -1,0 +1,50 @@
+---
+author: Rishabh Dewangan
+title: Curved Parallel Coordinates
+description: A parallel coordinate plot with smooth, monotonic curves to reduce visual clutter.
+tags: [visualization, plotly, parallel-coordinates, explainable-ai]
+optuna_versions: [3.6.1]
+license: MIT License
+---
+
+## Abstract
+
+This package provides an Optuna parallel coordinate plot using Piecewise Cubic Hermite Interpolating Polynomials (Pchip) for smooth, monotonic curves. This reduces visual clutter and makes individual trial trajectories easier to track in high-dimensional spaces compared to standard straight-line plots.
+
+## APIs
+
+- `plot_curved_parallel_coordinate(study: optuna.Study, params: list[str] | None = None, points_per_segment: int = 50) -> plotly.graph_objects.Figure`
+  - `study`: The `optuna.Study` object (plots completed trials only).
+  - `params`: List of parameter names to plot. Defaults to all parameters.
+  - `points_per_segment`: Curve resolution. Defaults to `50`.
+
+## Installation
+
+This package relies on standard mathematical and visualization libraries.
+
+```shell
+$ pip install scipy plotly numpy optuna
+```
+
+## Example
+
+```python
+import optuna
+import optunahub
+
+def objective(trial):
+    x = trial.suggest_float("x", -10, 10)
+    y = trial.suggest_float("y", -10, 10)
+    z = trial.suggest_float("z", -5, 5)
+    return x**2 + y**2 + z**2
+
+study = optuna.create_study()
+study.optimize(objective, n_trials=30)
+
+# Load the curved parallel coordinate module from OptunaHub
+module = optunahub.load_module(package="visualization/plot_curved_parallel_coordinate")
+
+# Generate and display the plot
+fig = module.plot_curved_parallel_coordinate(study)
+fig.show()
+```

--- a/package/visualization/plot_curved_parallel_coordinate/README.md
+++ b/package/visualization/plot_curved_parallel_coordinate/README.md
@@ -3,7 +3,7 @@ author: Rishabh Dewangan
 title: Curved Parallel Coordinates
 description: A parallel coordinate plot with smooth, monotonic curves to reduce visual clutter.
 tags: [visualization, plotly, parallel-coordinates, explainable-ai]
-optuna_versions: [3.6.1]
+optuna_versions: [4.7.0]
 license: MIT License
 ---
 

--- a/package/visualization/plot_curved_parallel_coordinate/__init__.py
+++ b/package/visualization/plot_curved_parallel_coordinate/__init__.py
@@ -1,0 +1,4 @@
+from .plot_curved_parallel_coordinate import plot_curved_parallel_coordinate
+
+
+__all__ = ["plot_curved_parallel_coordinate"]

--- a/package/visualization/plot_curved_parallel_coordinate/example.py
+++ b/package/visualization/plot_curved_parallel_coordinate/example.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+
+import optuna
+import optunahub
+
+
+def objective(trial: optuna.Trial) -> float:
+    x = trial.suggest_float("x", -5, 5)
+    y = trial.suggest_float("y", -5, 5)
+    z = trial.suggest_float("z", -10, 10)
+    return (x - 2) ** 2 + (y + 3) ** 2 + z**2
+
+
+if __name__ == "__main__":
+    study = optuna.create_study(direction="minimize")
+    study.optimize(objective, n_trials=50)
+
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    package_root = os.path.abspath(os.path.join(current_dir, "../../"))
+
+    module = optunahub.load_local_module(
+        package="visualization/plot_curved_parallel_coordinate",
+        registry_root=package_root,
+    )
+
+    fig = module.plot_curved_parallel_coordinate(study)
+    fig.show()

--- a/package/visualization/plot_curved_parallel_coordinate/plot_curved_parallel_coordinate.py
+++ b/package/visualization/plot_curved_parallel_coordinate/plot_curved_parallel_coordinate.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import List
+from typing import Optional
+
+import numpy as np
+import optuna
+from optuna.trial import TrialState
+from plotly.colors import sample_colorscale
+import plotly.graph_objects as go
+from scipy.interpolate import PchipInterpolator
+
+
+def plot_curved_parallel_coordinate(
+    study: optuna.Study, params: Optional[List[str]] = None, points_per_segment: int = 50
+) -> go.Figure:
+    """Plot a curved parallel coordinate plot for the study."""
+
+    trials = [t for t in study.trials if t.state == TrialState.COMPLETE]
+    if not trials:
+        return go.Figure()
+
+    if params is None:
+        params = sorted(list(set(k for t in trials for k in t.params.keys())))
+
+    if len(params) < 1:
+        raise ValueError("Curved parallel coordinates require at least one parameter.")
+
+    objectives = [t.value for t in trials]
+    min_obj, max_obj = min(objectives), max(objectives)
+
+    plot_dims = ["Objective Value"] + params
+    params_bounds = {"Objective Value": (min_obj, max_obj)}
+
+    for p in params:
+        vals = [t.params.get(p, np.nan) for t in trials]
+        numeric_vals = [v for v in vals if isinstance(v, (int, float)) and not np.isnan(v)]
+        if numeric_vals:
+            params_bounds[p] = (min(numeric_vals), max(numeric_vals))
+        else:
+            params_bounds[p] = (0, 1)
+
+    data_matrix = []
+    for t in trials:
+        row = []
+        val = t.value
+        norm_obj = (val - min_obj) / (max_obj - min_obj) if max_obj > min_obj else 0.5
+        row.append(norm_obj)
+
+        for p in params:
+            val = t.params.get(p, np.nan)
+            if isinstance(val, (int, float)) and not np.isnan(val):
+                p_min, p_max = params_bounds[p]
+                norm_val = (val - p_min) / (p_max - p_min) if p_max > p_min else 0.5
+                row.append(norm_val)
+            else:
+                row.append(np.nan)
+        data_matrix.append(row)
+
+    fig = go.Figure()
+    x_coords = np.arange(len(plot_dims))
+
+    colorscale = "Blues_r"
+    for idx, row in enumerate(data_matrix):
+        if np.isnan(row).any():
+            continue
+
+        interpolator = PchipInterpolator(x_coords, row)
+        x_smooth = np.linspace(x_coords.min(), x_coords.max(), len(plot_dims) * points_per_segment)
+        y_smooth = interpolator(x_smooth)
+
+        val = objectives[idx]
+        norm_obj = (val - min_obj) / (max_obj - min_obj) if max_obj > min_obj else 0.5
+        line_color = sample_colorscale(colorscale, [norm_obj])[0]
+
+        fig.add_trace(
+            go.Scatter(
+                x=x_smooth,
+                y=y_smooth,
+                mode="lines",
+                line=dict(color=line_color, width=1.5),
+                opacity=0.4,
+                hoverinfo="skip",
+                showlegend=False,
+            )
+        )
+
+    for i, p in enumerate(plot_dims):
+        p_min, p_max = params_bounds[p]
+        fig.add_shape(type="line", x0=i, y0=0, x1=i, y1=1, line=dict(color="#777777", width=1.5))
+        fig.add_annotation(x=i, y=1.05, text=p, showarrow=False, font=dict(size=14))
+        fig.add_annotation(x=i, y=-0.05, text=f"{p_min:.2f}", showarrow=False)
+        fig.add_annotation(x=i, y=1.0, text=f"{p_max:.2f}", showarrow=False, xanchor="left")
+
+    fig.add_trace(
+        go.Scatter(
+            x=[None],
+            y=[None],
+            mode="markers",
+            marker=dict(
+                colorscale=colorscale,
+                cmin=min_obj,
+                cmax=max_obj,
+                color=[min_obj, max_obj],
+                colorbar=dict(title="Objective Value", thickness=20),
+                showscale=True,
+            ),
+            hoverinfo="skip",
+            showlegend=False,
+        )
+    )
+
+    fig.update_layout(
+        title="Curved Parallel Coordinates",
+        xaxis=dict(showgrid=False, zeroline=False, visible=False),
+        yaxis=dict(showgrid=False, zeroline=False, visible=False),
+        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor="rgba(0,0,0,0)",
+        showlegend=False,
+    )
+
+    return fig

--- a/package/visualization/plot_curved_parallel_coordinate/requirements.txt
+++ b/package/visualization/plot_curved_parallel_coordinate/requirements.txt
@@ -1,0 +1,4 @@
+optuna
+plotly
+numpy
+scipy


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

Standard parallel coordinate plots get incredibly cluttered in high-dimensional spaces. This package swaps straight lines for smooth, monotonic curves, to help track individual trial paths.

Addresses:
* optuna/optuna#5287
* optuna/optunahub-registry#115

## Description of the changes

* Uses `scipy.interpolate.PchipInterpolator` to enforce curve monotonicity and prevent visual overshoot (Runge's phenomenon).
* Implements dynamic colorbar mapping for objective values to match native Optuna behavior.

| Native Plot (50 trials) | Curved Pchip Plot (50 trials) |
|:---:|:---:|
| <img width="450" alt="before" src="https://github.com/user-attachments/assets/d448a023-2cc4-414a-a111-f35259f6db6c" /> | <img width="450" alt="after" src="https://github.com/user-attachments/assets/92bd3d28-fa1e-47bd-95f8-ef556213adaa" /> |

## TODO List towards PR Merge

Please remove this section if this PR is not an addition of a new package.
Otherwise, please check the following TODO list:

- [x] Copy `./template/` to create your package
- [x] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [x] Fill out `README.md` in your package
- [x] Add import statements of your function or class names to be used in `__init__.py`
- [x] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [x] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [x] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)