### PR TITLE
Add terminator callback

### DIFF
--- a/package/callbacks/terminator/LICENSE
+++ b/package/callbacks/terminator/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Optuna team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/callbacks/terminator/README.md
+++ b/package/callbacks/terminator/README.md
@@ -1,0 +1,181 @@
+---
+author: Alnusjaponica, HideakiImamura, Sip4818, c-bata, contramundum53, cross32768, eukaryo, g-votte, gen740, hvy, jot-s-bindra, kAIto47802, nabenabe0928, not522, nzw0301, sawa3030, smygw72, torotoki, toshihikoyanase, virendrapatil24, and y0z
+title: Terminator Callback
+description: A callback to automatically stop the optimization when further improvement is unlikely.
+tags: [callback, terminator, early-stopping, built-in]
+optuna_versions: [4.0.0]
+license: MIT License
+---
+
+## Abstract
+
+This callback implements an automatic stopping mechanism for Optuna studies, aiming to avoid unnecessary computation. The optimization is terminated when the statistical error of the objective function (e.g., cross-validation error) exceeds the room left for optimization (i.e., the estimated potential for improvement).
+
+The mechanism is described in the following papers:
+
+- `A. Makarova et al. Automatic termination for hyperparameter optimization. <https://proceedings.mlr.press/v188/makarova22a.html>`\_\_
+- `H. Ishibashi et al. A stopping criterion for Bayesian optimization by the gap of expected minimum simple regrets. <https://proceedings.mlr.press/v206/ishibashi23a.html>`\_\_
+
+## APIs
+
+### Callback
+
+- `TerminatorCallback(terminator: BaseTerminator | None = None)`
+  - A callback that wraps a `Terminator` so that it can be passed to `study.optimize` via the `callbacks` argument. When the terminator judges that the study should be stopped, `study.stop()` is called.
+  - `terminator`: A terminator object that determines whether to terminate the optimization. Defaults to a `Terminator` object with default `improvement_evaluator` and `error_evaluator`.
+
+### Terminator
+
+- `Terminator(improvement_evaluator: BaseImprovementEvaluator | None = None, error_evaluator: BaseErrorEvaluator | None = None, min_n_trials: int = 20)`
+  - `improvement_evaluator`: An evaluator for the room left for optimization. Defaults to `RegretBoundEvaluator`.
+  - `error_evaluator`: An evaluator for the statistical error, e.g. cross-validation error. Defaults to `CrossValidationErrorEvaluator` (or `StaticErrorEvaluator(constant=0)` when `improvement_evaluator` is a `BestValueStagnationEvaluator`).
+  - `min_n_trials`: The minimum number of trials before termination is considered. Must be a positive integer. Defaults to `20`.
+  - `Terminator.should_terminate(study: Study) -> bool`: Judges whether the study should be terminated based on the reported values.
+
+### Improvement evaluators
+
+- `RegretBoundEvaluator(top_trials_ratio: float = 0.5, min_n_trials: int = 20, seed: int | None = None)`
+  - Estimates an upper bound on the regret of the current best solution under a Gaussian process model assumption.
+- `BestValueStagnationEvaluator(max_stagnation_trials: int = 30)`
+  - Evaluates the number of remaining trials before the best value has stagnated for `max_stagnation_trials` trials.
+- `EMMREvaluator(deterministic_objective: bool = False, delta: float = 0.1, min_n_trials: int = 2, seed: int | None = None)`
+  - Evaluates the Expected Minimum Model Regret (EMMR), an upper bound of the expected minimum simple regret. Intended to be paired with `MedianErrorEvaluator`.
+
+### Error evaluators
+
+- `CrossValidationErrorEvaluator()`
+  - Uses the scaled variance of the cross-validation scores of the best trial as the statistical error. Requires `report_cross_validation_scores` to be called inside the objective function.
+- `StaticErrorEvaluator(constant: float)`
+  - Always returns a constant value as the error estimate.
+- `MedianErrorEvaluator(paired_improvement_evaluator: BaseImprovementEvaluator, warm_up_trials: int = 10, n_initial_trials: int = 20, threshold_ratio: float = 0.01)`
+  - Returns a threshold computed as a ratio to the median of the initial improvement values. Intended to be paired with `EMMREvaluator`.
+- `report_cross_validation_scores(trial: Trial, scores: list[float]) -> None`
+  - Reports the cross-validation scores of a trial. Must be called inside the objective function when using `CrossValidationErrorEvaluator`. The length of `scores` must be greater than one.
+
+### Base classes
+
+- `BaseTerminator`, `BaseImprovementEvaluator`, and `BaseErrorEvaluator` are provided for implementing custom terminators and evaluators.
+
+## Example
+
+### Add the Terminator callback to Optuna optimization
+
+```python
+from sklearn.datasets import load_wine
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import KFold
+
+import optuna
+import optunahub
+
+
+module = optunahub.load_module("callbacks/terminator")
+TerminatorCallback = module.TerminatorCallback
+report_cross_validation_scores = module.report_cross_validation_scores
+
+
+def objective(trial):
+    X, y = load_wine(return_X_y=True)
+
+    clf = RandomForestClassifier(
+        max_depth=trial.suggest_int("max_depth", 2, 32),
+        min_samples_split=trial.suggest_float("min_samples_split", 0, 1),
+        criterion=trial.suggest_categorical("criterion", ("gini", "entropy")),
+    )
+
+    scores = cross_val_score(clf, X, y, cv=KFold(n_splits=5, shuffle=True))
+    report_cross_validation_scores(trial, scores)
+    return scores.mean()
+
+
+study = optuna.create_study(direction="maximize")
+terminator = TerminatorCallback()
+study.optimize(objective, n_trials=50, callbacks=[terminator])
+```
+
+### Use the Terminator directly within an ask-and-tell loop
+
+```python
+import logging
+
+from sklearn.datasets import load_wine
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import KFold
+
+import optuna
+import optunahub
+
+
+module = optunahub.load_module("callbacks/terminator")
+Terminator = module.Terminator
+report_cross_validation_scores = module.report_cross_validation_scores
+
+
+study = optuna.create_study(direction="maximize")
+terminator = Terminator()
+min_n_trials = 20
+
+while True:
+    trial = study.ask()
+
+    X, y = load_wine(return_X_y=True)
+
+    clf = RandomForestClassifier(
+        max_depth=trial.suggest_int("max_depth", 2, 32),
+        min_samples_split=trial.suggest_float("min_samples_split", 0, 1),
+        criterion=trial.suggest_categorical("criterion", ("gini", "entropy")),
+    )
+
+    scores = cross_val_score(clf, X, y, cv=KFold(n_splits=5, shuffle=True))
+    report_cross_validation_scores(trial, scores)
+
+    value = scores.mean()
+    logging.info(f"Trial #{trial.number} finished with value {value}.")
+    study.tell(trial, value)
+
+    if trial.number > min_n_trials and terminator.should_terminate(study):
+        logging.info("Terminated by Optuna Terminator!")
+        break
+```
+
+### Use EMMR-based termination
+
+```python
+import optuna
+import optunahub
+
+
+module = optunahub.load_module("callbacks/terminator")
+Terminator = module.Terminator
+EMMREvaluator = module.EMMREvaluator
+MedianErrorEvaluator = module.MedianErrorEvaluator
+
+
+sampler = optuna.samplers.TPESampler(seed=0)
+study = optuna.create_study(sampler=sampler, direction="minimize")
+
+emmr_improvement_evaluator = EMMREvaluator()
+median_error_evaluator = MedianErrorEvaluator(emmr_improvement_evaluator)
+terminator = Terminator(
+    improvement_evaluator=emmr_improvement_evaluator,
+    error_evaluator=median_error_evaluator,
+)
+
+for i in range(1000):
+    trial = study.ask()
+
+    ys = [trial.suggest_float(f"x{i}", -10.0, 10.0) for i in range(5)]
+    value = sum(ys[i] ** 2 for i in range(5))
+
+    study.tell(trial, value)
+
+    if terminator.should_terminate(study):
+        # Terminated by Optuna Terminator!
+        break
+```
+
+## Others
+
+This package is ported from the [`optuna.terminator`](https://optuna.readthedocs.io/en/stable/reference/terminator.html) module. Please refer to the Optuna documentation for further details on the terminator mechanism.

--- a/package/callbacks/terminator/__init__.py
+++ b/package/callbacks/terminator/__init__.py
@@ -1,0 +1,28 @@
+from .callback import TerminatorCallback
+from .erroreval import BaseErrorEvaluator
+from .erroreval import CrossValidationErrorEvaluator
+from .erroreval import report_cross_validation_scores
+from .erroreval import StaticErrorEvaluator
+from .improvement.emmr import EMMREvaluator
+from .improvement.evaluator import BaseImprovementEvaluator
+from .improvement.evaluator import BestValueStagnationEvaluator
+from .improvement.evaluator import RegretBoundEvaluator
+from .median_erroreval import MedianErrorEvaluator
+from .terminator import BaseTerminator
+from .terminator import Terminator
+
+
+__all__ = [
+    "TerminatorCallback",
+    "BaseErrorEvaluator",
+    "CrossValidationErrorEvaluator",
+    "report_cross_validation_scores",
+    "StaticErrorEvaluator",
+    "MedianErrorEvaluator",
+    "BaseImprovementEvaluator",
+    "BestValueStagnationEvaluator",
+    "RegretBoundEvaluator",
+    "EMMREvaluator",
+    "BaseTerminator",
+    "Terminator",
+]

--- a/package/callbacks/terminator/callback.py
+++ b/package/callbacks/terminator/callback.py
@@ -20,15 +20,15 @@ _logger = get_logger(__name__)
 class TerminatorCallback:
     """A callback that terminates the optimization using Terminator.
 
-    This class implements a callback which wraps :class:`~optuna.terminator.Terminator`
+    This class implements a callback which wraps ``Terminator``
     so that it can be used with the :func:`~optuna.study.Study.optimize` method.
 
     Args:
         terminator:
             A terminator object which determines whether to terminate the optimization by
             assessing the room for optimization and statistical error. Defaults to a
-            :class:`~optuna.terminator.Terminator` object with default
-            ``improvement_evaluator`` and ``error_evaluator``.
+            ``Terminator`` object with default ``improvement_evaluator`` and
+            ``error_evaluator``.
 
     Example:
 
@@ -67,7 +67,7 @@ class TerminatorCallback:
             study.optimize(objective, n_trials=50, callbacks=[terminator])
 
     .. seealso::
-        Please refer to :class:`~optuna.terminator.Terminator` for the details of
+        Please refer to ``Terminator`` for the details of
         the terminator mechanism.
     """
 

--- a/package/callbacks/terminator/callback.py
+++ b/package/callbacks/terminator/callback.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
+from optuna._warnings import optuna_warn
+from optuna.logging import get_logger
+
+from .terminator import Terminator
+
+
+if TYPE_CHECKING:
+    from optuna.study.study import Study
+    from optuna.trial import FrozenTrial
+
+    from .terminator import BaseTerminator
+
+
+_logger = get_logger(__name__)
+
+_DEPRECATION_WARNING_MESSAGE = _DEPRECATION_WARNING_TEMPLATE.format(
+    name="`optuna.terminator` module",
+    d_ver="4.9.0",
+    r_ver="6.0.0",
+)
+
+
+class TerminatorCallback:
+    """A callback that terminates the optimization using Terminator.
+
+    This class implements a callback which wraps :class:`~optuna.terminator.Terminator`
+    so that it can be used with the :func:`~optuna.study.Study.optimize` method.
+
+    Args:
+        terminator:
+            A terminator object which determines whether to terminate the optimization by
+            assessing the room for optimization and statistical error. Defaults to a
+            :class:`~optuna.terminator.Terminator` object with default
+            ``improvement_evaluator`` and ``error_evaluator``.
+
+    Example:
+
+        .. testcode::
+
+            from sklearn.datasets import load_wine
+            from sklearn.ensemble import RandomForestClassifier
+            from sklearn.model_selection import cross_val_score
+            from sklearn.model_selection import KFold
+
+            import optuna
+            from optuna.terminator import TerminatorCallback
+            from optuna.terminator import report_cross_validation_scores
+
+
+            def objective(trial):
+                X, y = load_wine(return_X_y=True)
+
+                clf = RandomForestClassifier(
+                    max_depth=trial.suggest_int("max_depth", 2, 32),
+                    min_samples_split=trial.suggest_float("min_samples_split", 0, 1),
+                    criterion=trial.suggest_categorical("criterion", ("gini", "entropy")),
+                )
+
+                scores = cross_val_score(clf, X, y, cv=KFold(n_splits=5, shuffle=True))
+                report_cross_validation_scores(trial, scores)
+                return scores.mean()
+
+
+            study = optuna.create_study(direction="maximize")
+            terminator = TerminatorCallback()
+            study.optimize(objective, n_trials=50, callbacks=[terminator])
+
+    .. seealso::
+        Please refer to :class:`~optuna.terminator.Terminator` for the details of
+        the terminator mechanism.
+    """
+
+    def __init__(self, terminator: BaseTerminator | None = None) -> None:
+        optuna_warn(_DEPRECATION_WARNING_MESSAGE, FutureWarning)
+        self._terminator = terminator or Terminator()
+
+    def __call__(self, study: Study, trial: FrozenTrial) -> None:
+        should_terminate = self._terminator.should_terminate(study=study)
+
+        if should_terminate:
+            _logger.info("The study has been stopped by the terminator.")
+            study.stop()

--- a/package/callbacks/terminator/callback.py
+++ b/package/callbacks/terminator/callback.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
-from optuna._warnings import optuna_warn
 from optuna.logging import get_logger
 
 from .terminator import Terminator
@@ -17,12 +15,6 @@ if TYPE_CHECKING:
 
 
 _logger = get_logger(__name__)
-
-_DEPRECATION_WARNING_MESSAGE = _DEPRECATION_WARNING_TEMPLATE.format(
-    name="`optuna.terminator` module",
-    d_ver="4.9.0",
-    r_ver="6.0.0",
-)
 
 
 class TerminatorCallback:
@@ -76,7 +68,6 @@ class TerminatorCallback:
     """
 
     def __init__(self, terminator: BaseTerminator | None = None) -> None:
-        optuna_warn(_DEPRECATION_WARNING_MESSAGE, FutureWarning)
         self._terminator = terminator or Terminator()
 
     def __call__(self, study: Study, trial: FrozenTrial) -> None:

--- a/package/callbacks/terminator/callback.py
+++ b/package/callbacks/terminator/callback.py
@@ -40,8 +40,12 @@ class TerminatorCallback:
             from sklearn.model_selection import KFold
 
             import optuna
-            from optuna.terminator import TerminatorCallback
-            from optuna.terminator import report_cross_validation_scores
+            import optunahub
+
+
+            module = optunahub.load_module("callbacks/terminator")
+            TerminatorCallback = module.TerminatorCallback
+            report_cross_validation_scores = module.report_cross_validation_scores
 
 
             def objective(trial):

--- a/package/callbacks/terminator/erroreval.py
+++ b/package/callbacks/terminator/erroreval.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import abc
+from typing import cast
+from typing import TYPE_CHECKING
+
+import numpy as np
+from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
+from optuna._experimental import experimental_class
+from optuna._warnings import optuna_warn
+from optuna.study import StudyDirection
+from optuna.trial._state import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna.trial import FrozenTrial
+    from optuna.trial import Trial
+
+
+_CROSS_VALIDATION_SCORES_KEY = "terminator:cv_scores"
+_DEPRECATION_WARNING_MESSAGE = _DEPRECATION_WARNING_TEMPLATE.format(
+    name="`optuna.terminator` module",
+    d_ver="4.9.0",
+    r_ver="6.0.0",
+)
+
+
+class BaseErrorEvaluator(metaclass=abc.ABCMeta):
+    """Base class for error evaluators."""
+
+    @abc.abstractmethod
+    def evaluate(
+        self,
+        trials: list[FrozenTrial],
+        study_direction: StudyDirection,
+    ) -> float:
+        pass
+
+
+@experimental_class("3.2.0")
+class CrossValidationErrorEvaluator(BaseErrorEvaluator):
+    """An error evaluator for objective functions based on cross-validation.
+
+    This evaluator evaluates the objective function's statistical error, which comes from the
+    randomness of dataset. This evaluator assumes that the objective function is the average of
+    the cross-validation and uses the scaled variance of the cross-validation scores in the best
+    trial at the moment as the statistical error.
+
+    """
+
+    def evaluate(
+        self,
+        trials: list[FrozenTrial],
+        study_direction: StudyDirection,
+    ) -> float:
+        """Evaluate the statistical error of the objective function based on cross-validation.
+
+        Args:
+            trials:
+                A list of trials to consider. The best trial in ``trials`` is used to compute the
+                statistical error.
+
+            study_direction:
+                The direction of the study.
+
+        Returns:
+            A float representing the statistical error of the objective function.
+
+        """
+        trials = [trial for trial in trials if trial.state == TrialState.COMPLETE]
+        assert len(trials) > 0
+
+        if study_direction == StudyDirection.MAXIMIZE:
+            best_trial = max(trials, key=lambda t: cast("float", t.value))
+        else:
+            best_trial = min(trials, key=lambda t: cast("float", t.value))
+
+        best_trial_attrs = best_trial.system_attrs
+        if _CROSS_VALIDATION_SCORES_KEY in best_trial_attrs:
+            cv_scores = best_trial_attrs[_CROSS_VALIDATION_SCORES_KEY]
+        else:
+            raise ValueError(
+                "Cross-validation scores have not been reported. Please call "
+                "`report_cross_validation_scores(trial, scores)` during a trial and pass the "
+                "list of scores as `scores`."
+            )
+
+        k = len(cv_scores)
+        assert k > 1, "Should be guaranteed by `report_cross_validation_scores`."
+        scale = 1 / k + 1 / (k - 1)
+
+        var = scale * np.var(cv_scores)
+        std = np.sqrt(var)
+
+        return float(std)
+
+
+def report_cross_validation_scores(trial: Trial, scores: list[float]) -> None:
+    """A function to report cross-validation scores of a trial.
+
+    This function should be called within the objective function to report the cross-validation
+    scores. The reported scores are used to evaluate the statistical error for termination
+    judgement.
+
+    Args:
+        trial:
+            A :class:`~optuna.trial.Trial` object to report the cross-validation scores.
+        scores:
+            The cross-validation scores of the trial.
+
+    """
+    optuna_warn(_DEPRECATION_WARNING_MESSAGE, FutureWarning)
+
+    if len(scores) <= 1:
+        raise ValueError("The length of `scores` is expected to be greater than one.")
+    trial.storage.set_trial_system_attr(trial._trial_id, _CROSS_VALIDATION_SCORES_KEY, scores)
+
+
+@experimental_class("3.2.0")
+class StaticErrorEvaluator(BaseErrorEvaluator):
+    """An error evaluator that always returns a constant value.
+
+    This evaluator can be used to terminate the optimization when the evaluated improvement
+    potential is below the fixed threshold.
+
+    Args:
+        constant:
+            A user-specified constant value to always return as an error estimate.
+
+    """
+
+    def __init__(self, constant: float) -> None:
+        self._constant = constant
+
+    def evaluate(
+        self,
+        trials: list[FrozenTrial],
+        study_direction: StudyDirection,
+    ) -> float:
+        return self._constant

--- a/package/callbacks/terminator/erroreval.py
+++ b/package/callbacks/terminator/erroreval.py
@@ -5,9 +5,6 @@ from typing import cast
 from typing import TYPE_CHECKING
 
 import numpy as np
-from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
-from optuna._experimental import experimental_class
-from optuna._warnings import optuna_warn
 from optuna.study import StudyDirection
 from optuna.trial._state import TrialState
 
@@ -18,11 +15,6 @@ if TYPE_CHECKING:
 
 
 _CROSS_VALIDATION_SCORES_KEY = "terminator:cv_scores"
-_DEPRECATION_WARNING_MESSAGE = _DEPRECATION_WARNING_TEMPLATE.format(
-    name="`optuna.terminator` module",
-    d_ver="4.9.0",
-    r_ver="6.0.0",
-)
 
 
 class BaseErrorEvaluator(metaclass=abc.ABCMeta):
@@ -37,7 +29,6 @@ class BaseErrorEvaluator(metaclass=abc.ABCMeta):
         pass
 
 
-@experimental_class("3.2.0")
 class CrossValidationErrorEvaluator(BaseErrorEvaluator):
     """An error evaluator for objective functions based on cross-validation.
 
@@ -109,14 +100,12 @@ def report_cross_validation_scores(trial: Trial, scores: list[float]) -> None:
             The cross-validation scores of the trial.
 
     """
-    optuna_warn(_DEPRECATION_WARNING_MESSAGE, FutureWarning)
 
     if len(scores) <= 1:
         raise ValueError("The length of `scores` is expected to be greater than one.")
     trial.storage.set_trial_system_attr(trial._trial_id, _CROSS_VALIDATION_SCORES_KEY, scores)
 
 
-@experimental_class("3.2.0")
 class StaticErrorEvaluator(BaseErrorEvaluator):
     """An error evaluator that always returns a constant value.
 

--- a/package/callbacks/terminator/improvement/emmr.py
+++ b/package/callbacks/terminator/improvement/emmr.py
@@ -72,9 +72,13 @@ class EMMREvaluator(BaseImprovementEvaluator):
         .. testcode::
 
             import optuna
-            from optuna.terminator import EMMREvaluator
-            from optuna.terminator import MedianErrorEvaluator
-            from optuna.terminator import Terminator
+            import optunahub
+
+
+            module = optunahub.load_module("callbacks/terminator")
+            EMMREvaluator = module.EMMREvaluator
+            MedianErrorEvaluator = module.MedianErrorEvaluator
+            Terminator = module.Terminator
 
             sampler = optuna.samplers.TPESampler(seed=0)
             study = optuna.create_study(sampler=sampler, direction="minimize")

--- a/package/callbacks/terminator/improvement/emmr.py
+++ b/package/callbacks/terminator/improvement/emmr.py
@@ -6,7 +6,6 @@ from typing import cast
 from typing import TYPE_CHECKING
 
 import numpy as np
-from optuna._experimental import experimental_class
 from optuna._warnings import optuna_warn
 from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.search_space import intersection_search_space
@@ -36,7 +35,6 @@ else:
 MARGIN_FOR_NUMARICAL_STABILITY = 0.1
 
 
-@experimental_class("4.0.0")
 class EMMREvaluator(BaseImprovementEvaluator):
     """Evaluates a kind of regrets, called the Expected Minimum Model Regret(EMMR).
 

--- a/package/callbacks/terminator/improvement/emmr.py
+++ b/package/callbacks/terminator/improvement/emmr.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import math
+import sys
+from typing import cast
+from typing import TYPE_CHECKING
+
+import numpy as np
+from optuna._experimental import experimental_class
+from optuna._warnings import optuna_warn
+from optuna.samplers._lazy_random_state import LazyRandomState
+from optuna.search_space import intersection_search_space
+from optuna.study import StudyDirection
+from optuna.trial import TrialState
+
+from .evaluator import _compute_standardized_regret_bound
+from .evaluator import BaseImprovementEvaluator
+
+
+if TYPE_CHECKING:
+    from optuna._gp import gp
+    from optuna._gp import prior
+    from optuna._gp import search_space as gp_search_space
+    from optuna.trial import FrozenTrial
+    import scipy.stats as scipy_stats
+    import torch
+else:
+    from optuna._imports import _LazyImport
+
+    torch = _LazyImport("torch")
+    gp = _LazyImport("optuna._gp.gp")
+    prior = _LazyImport("optuna._gp.prior")
+    gp_search_space = _LazyImport("optuna._gp.search_space")
+    scipy_stats = _LazyImport("scipy.stats")
+
+MARGIN_FOR_NUMARICAL_STABILITY = 0.1
+
+
+@experimental_class("4.0.0")
+class EMMREvaluator(BaseImprovementEvaluator):
+    """Evaluates a kind of regrets, called the Expected Minimum Model Regret(EMMR).
+
+    EMMR is an upper bound of "expected minimum simple regret" in the optimization process.
+
+    Expected minimum simple regret is a quantity that converges to zero only if the
+    optimization process has found the global optima.
+
+    For further information about expected minimum simple regret and the algorithm,
+    please refer to the following paper:
+
+    - `A stopping criterion for Bayesian optimization by the gap of expected minimum simple
+      regrets <https://proceedings.mlr.press/v206/ishibashi23a.html>`__
+
+    Also, there is our blog post explaining this evaluator:
+
+    - `Introducing A New Terminator: Early Termination of Black-box Optimization Based on
+      Expected Minimum Model Regret
+      <https://medium.com/optuna/introducing-a-new-terminator-early-termination-of-black-box-optimization-based-on-expected-9a660774fcdb>`__
+
+    Args:
+        deterministic_objective:
+            A boolean value which indicates whether the objective function is deterministic.
+            Default is :obj:`False`.
+        delta:
+            A float number related to the criterion for termination. Default to 0.1.
+            For further information about this parameter, please see the aforementioned paper.
+        min_n_trials:
+            A minimum number of complete trials to compute the criterion. Default to 2.
+        seed:
+            A random seed for EMMREvaluator.
+
+    Example:
+
+        .. testcode::
+
+            import optuna
+            from optuna.terminator import EMMREvaluator
+            from optuna.terminator import MedianErrorEvaluator
+            from optuna.terminator import Terminator
+
+            sampler = optuna.samplers.TPESampler(seed=0)
+            study = optuna.create_study(sampler=sampler, direction="minimize")
+            emmr_improvement_evaluator = EMMREvaluator()
+            median_error_evaluator = MedianErrorEvaluator(emmr_improvement_evaluator)
+            terminator = Terminator(
+                improvement_evaluator=emmr_improvement_evaluator,
+                error_evaluator=median_error_evaluator,
+            )
+
+
+            for i in range(1000):
+                trial = study.ask()
+
+                ys = [trial.suggest_float(f"x{i}", -10.0, 10.0) for i in range(5)]
+                value = sum(ys[i] ** 2 for i in range(5))
+
+                study.tell(trial, value)
+
+                if terminator.should_terminate(study):
+                    # Terminated by Optuna Terminator!
+                    break
+
+    """
+
+    def __init__(
+        self,
+        deterministic_objective: bool = False,
+        delta: float = 0.1,
+        min_n_trials: int = 2,
+        seed: int | None = None,
+    ) -> None:
+        if min_n_trials <= 1 or not np.isfinite(min_n_trials):
+            raise ValueError("`min_n_trials` is expected to be a finite integer more than one.")
+
+        self._deterministic = deterministic_objective
+        self._delta = delta
+        self.min_n_trials = min_n_trials
+        self._rng = LazyRandomState(seed)
+
+    def evaluate(self, trials: list[FrozenTrial], study_direction: StudyDirection) -> float:
+        optuna_search_space = intersection_search_space(trials)
+        complete_trials = [t for t in trials if t.state == TrialState.COMPLETE]
+
+        if len(complete_trials) < self.min_n_trials:
+            return sys.float_info.max * MARGIN_FOR_NUMARICAL_STABILITY  # Do not terminate.
+
+        search_space = gp_search_space.SearchSpace(optuna_search_space)
+        normalized_params = search_space.get_normalized_params(complete_trials)
+        if not search_space.dim:
+            optuna_warn(
+                f"{self.__class__.__name__} cannot consider any search space."
+                "Termination will never occur in this study."
+            )
+            return sys.float_info.max * MARGIN_FOR_NUMARICAL_STABILITY  # Do not terminate.
+
+        len_trials = len(complete_trials)
+        assert normalized_params.shape == (len_trials, search_space.dim)
+
+        # _gp module assumes that optimization direction is maximization
+        sign = -1 if study_direction == StudyDirection.MINIMIZE else 1
+        score_vals = np.array([cast("float", t.value) for t in complete_trials]) * sign
+        score_vals = gp.warn_and_convert_inf(score_vals)
+        standarized_score_vals = (score_vals - score_vals.mean()) / max(
+            sys.float_info.min, score_vals.std()
+        )
+
+        assert len(standarized_score_vals) == len(normalized_params)
+
+        gpr_t1 = gp.fit_kernel_params(  # Fit kernel with up to (t-1)-th observation
+            X=normalized_params[..., :-1, :],
+            Y=standarized_score_vals[:-1],
+            is_categorical=search_space.is_categorical,
+            log_prior=prior.default_log_prior,
+            minimum_noise=prior.DEFAULT_MINIMUM_NOISE_VAR,
+            gpr_cache=None,
+            deterministic_objective=self._deterministic,
+        )
+
+        gpr_t = gp.fit_kernel_params(  # Fit kernel with up to t-th observation
+            X=normalized_params,
+            Y=standarized_score_vals,
+            is_categorical=search_space.is_categorical,
+            log_prior=prior.default_log_prior,
+            minimum_noise=prior.DEFAULT_MINIMUM_NOISE_VAR,
+            gpr_cache=gpr_t1,
+            deterministic_objective=self._deterministic,
+        )
+
+        theta_t_star_index = int(np.argmax(standarized_score_vals))
+        theta_t1_star_index = int(np.argmax(standarized_score_vals[:-1]))
+        theta_t_star = normalized_params[theta_t_star_index, :]
+        theta_t1_star = normalized_params[theta_t1_star_index, :]
+        cov_t_between_theta_t_star_and_theta_t1_star = _compute_gp_posterior_cov_two_thetas(
+            normalized_params, gpr_t, theta_t_star_index, theta_t1_star_index
+        )
+        # Use gpr_t instead of gpr_t1 because KL Div. requires the same prior for both posterior.
+        # cf. Sec. 4.4 of https://proceedings.mlr.press/v206/ishibashi23a/ishibashi23a.pdf
+        mu_t1_theta_t_with_nu_t, variance_t1_theta_t_with_nu_t = _compute_gp_posterior(
+            normalized_params[-1, :], gpr_t
+        )
+        _, variance_t_theta_t1_star = _compute_gp_posterior(theta_t1_star, gpr_t)
+        mu_t_theta_t_star, variance_t_theta_t_star = _compute_gp_posterior(theta_t_star, gpr_t)
+        mu_t1_theta_t1_star, _ = _compute_gp_posterior(theta_t1_star, gpr_t1)
+
+        y_t = standarized_score_vals[-1]
+        kappa_t1 = _compute_standardized_regret_bound(
+            gpr_t1,
+            search_space,
+            normalized_params[:-1, :],
+            standarized_score_vals[:-1],
+            self._delta,
+            rng=self._rng.rng,
+        )
+
+        theorem1_delta_mu_t_star = mu_t1_theta_t1_star - mu_t_theta_t_star
+
+        alg1_delta_r_tilde_t_term1 = theorem1_delta_mu_t_star
+
+        theorem1_v = math.sqrt(
+            max(
+                1e-10,
+                variance_t_theta_t_star
+                - 2.0 * cov_t_between_theta_t_star_and_theta_t1_star
+                + variance_t_theta_t1_star,
+            )
+        )
+        theorem1_g = (mu_t_theta_t_star - mu_t1_theta_t1_star) / theorem1_v
+
+        alg1_delta_r_tilde_t_term2 = theorem1_v * scipy_stats.norm.pdf(theorem1_g)
+        alg1_delta_r_tilde_t_term3 = theorem1_v * theorem1_g * scipy_stats.norm.cdf(theorem1_g)
+
+        _lambda = prior.DEFAULT_MINIMUM_NOISE_VAR**-1
+        eq4_rhs_term1 = 0.5 * math.log(1.0 + _lambda * variance_t1_theta_t_with_nu_t)
+        eq4_rhs_term2 = (
+            -0.5 * variance_t1_theta_t_with_nu_t / (variance_t1_theta_t_with_nu_t + _lambda**-1)
+        )
+        eq4_rhs_term3 = (
+            0.5
+            * variance_t1_theta_t_with_nu_t
+            * (y_t - mu_t1_theta_t_with_nu_t) ** 2
+            / (variance_t1_theta_t_with_nu_t + _lambda**-1) ** 2
+        )
+
+        alg1_delta_r_tilde_t_term4 = kappa_t1 * math.sqrt(
+            0.5 * (eq4_rhs_term1 + eq4_rhs_term2 + eq4_rhs_term3)
+        )
+
+        return min(
+            sys.float_info.max * 0.5,
+            alg1_delta_r_tilde_t_term1
+            + alg1_delta_r_tilde_t_term2
+            + alg1_delta_r_tilde_t_term3
+            + alg1_delta_r_tilde_t_term4,
+        )
+
+
+def _compute_gp_posterior(x_params: np.ndarray, gpr: gp.GPRegressor) -> tuple[float, float]:
+    # best_params or normalized_params[..., -1, :]
+    mean, var = gpr.posterior(torch.from_numpy(x_params))
+    return mean.item(), var.item()
+
+
+def _compute_gp_posterior_cov_two_thetas(
+    normalized_params: np.ndarray, gpr: gp.GPRegressor, theta1_index: int, theta2_index: int
+) -> float:  # cov
+    if theta1_index == theta2_index:
+        return _compute_gp_posterior(normalized_params[theta1_index], gpr)[1]
+
+    _, covar = gpr.posterior(
+        torch.from_numpy(normalized_params[[theta1_index, theta2_index]]), joint=True
+    )
+    assert covar.shape == (2, 2)
+    return covar[0, 1].item()

--- a/package/callbacks/terminator/improvement/evaluator.py
+++ b/package/callbacks/terminator/improvement/evaluator.py
@@ -4,7 +4,6 @@ import abc
 from typing import TYPE_CHECKING
 
 import numpy as np
-from optuna._experimental import experimental_class
 from optuna.distributions import BaseDistribution
 from optuna.samplers._lazy_random_state import LazyRandomState
 from optuna.search_space import intersection_search_space
@@ -83,7 +82,6 @@ def _compute_standardized_regret_bound(
     return standardized_ucb_value - standardized_lcb_value  # standardized regret bound
 
 
-@experimental_class("3.2.0")
 class BaseImprovementEvaluator(metaclass=abc.ABCMeta):
     """Base class for improvement evaluators."""
 
@@ -92,7 +90,6 @@ class BaseImprovementEvaluator(metaclass=abc.ABCMeta):
         pass
 
 
-@experimental_class("3.2.0")
 class RegretBoundEvaluator(BaseImprovementEvaluator):
     """An error evaluator for upper bound on the regret with high-probability confidence.
 
@@ -191,7 +188,6 @@ class RegretBoundEvaluator(BaseImprovementEvaluator):
             )
 
 
-@experimental_class("3.4.0")
 class BestValueStagnationEvaluator(BaseImprovementEvaluator):
     """Evaluates the stagnation period of the best value in an optimization process.
 

--- a/package/callbacks/terminator/improvement/evaluator.py
+++ b/package/callbacks/terminator/improvement/evaluator.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import abc
+from typing import TYPE_CHECKING
+
+import numpy as np
+from optuna._experimental import experimental_class
+from optuna.distributions import BaseDistribution
+from optuna.samplers._lazy_random_state import LazyRandomState
+from optuna.search_space import intersection_search_space
+from optuna.study import StudyDirection
+from optuna.trial import TrialState
+
+
+if TYPE_CHECKING:
+    from optuna._gp import acqf as acqf_module
+    from optuna._gp import gp
+    from optuna._gp import optim_sample
+    from optuna._gp import prior
+    from optuna._gp import search_space as gp_search_space
+    from optuna.trial import FrozenTrial
+
+else:
+    from optuna._imports import _LazyImport
+
+    gp = _LazyImport("optuna._gp.gp")
+    optim_sample = _LazyImport("optuna._gp.optim_sample")
+    acqf_module = _LazyImport("optuna._gp.acqf")
+    prior = _LazyImport("optuna._gp.prior")
+    gp_search_space = _LazyImport("optuna._gp.search_space")
+
+DEFAULT_TOP_TRIALS_RATIO = 0.5
+DEFAULT_MIN_N_TRIALS = 20
+
+
+def _get_beta(n_params: int, n_trials: int, delta: float = 0.1) -> float:
+    # TODO(nabenabe0928): Check the original implementation to verify.
+    # Especially, |D| seems to be the domain size, but not the dimension based on Theorem 1.
+    beta = 2 * np.log(n_params * n_trials**2 * np.pi**2 / 6 / delta)
+
+    # The following div is according to the original paper: "We then further scale it down
+    # by a factor of 5 as defined in the experiments in
+    # `Srinivas et al. (2010) <https://dl.acm.org/doi/10.5555/3104322.3104451>`__"
+    beta /= 5
+
+    return beta
+
+
+def _compute_standardized_regret_bound(
+    gpr: gp.GPRegressor,
+    search_space: gp_search_space.SearchSpace,
+    normalized_top_n_params: np.ndarray,
+    standarized_top_n_values: np.ndarray,
+    delta: float = 0.1,
+    optimize_n_samples: int = 2048,
+    rng: np.random.RandomState | None = None,
+) -> float:
+    """
+    # In the original paper, f(x) was intended to be minimized, but here we would like to
+    # maximize f(x). Hence, the following changes happen:
+    #     1. min(ucb) over top trials becomes max(lcb) over top trials, and
+    #     2. min(lcb) over the search space becomes max(ucb) over the search space, and
+    #     3. Regret bound becomes max(ucb) over the search space minus max(lcb) over top trials.
+    """
+
+    n_trials, n_params = normalized_top_n_params.shape
+
+    # calculate max_ucb
+    beta = _get_beta(n_params, n_trials, delta)
+    ucb_acqf = acqf_module.UCB(gpr, search_space, beta)
+    # UCB over the search space. (Original: LCB over the search space. See Change 1 above.)
+    standardized_ucb_value = max(
+        ucb_acqf.eval_acqf_no_grad(normalized_top_n_params).max(),
+        optim_sample.optimize_acqf_sample(ucb_acqf, n_samples=optimize_n_samples, rng=rng)[1],
+    )
+
+    # calculate min_lcb
+    lcb_acqf = acqf_module.LCB(gpr=gpr, search_space=search_space, beta=beta)
+    # LCB over the top trials. (Original: UCB over the top trials. See Change 2 above.)
+    standardized_lcb_value = np.max(lcb_acqf.eval_acqf_no_grad(normalized_top_n_params))
+
+    # max(UCB) - max(LCB). (Original: min(UCB) - min(LCB). See Change 3 above.)
+    return standardized_ucb_value - standardized_lcb_value  # standardized regret bound
+
+
+@experimental_class("3.2.0")
+class BaseImprovementEvaluator(metaclass=abc.ABCMeta):
+    """Base class for improvement evaluators."""
+
+    @abc.abstractmethod
+    def evaluate(self, trials: list[FrozenTrial], study_direction: StudyDirection) -> float:
+        pass
+
+
+@experimental_class("3.2.0")
+class RegretBoundEvaluator(BaseImprovementEvaluator):
+    """An error evaluator for upper bound on the regret with high-probability confidence.
+
+    This evaluator evaluates the regret of current best solution, which defined as the difference
+    between the objective value of the best solution and of the global optimum. To be specific,
+    this evaluator calculates the upper bound on the regret based on the fact that empirical
+    estimator of the objective function is bounded by lower and upper confidence bounds with
+    high probability under the Gaussian process model assumption.
+
+    Args:
+        top_trials_ratio:
+            A ratio of top trials to be considered when estimating the regret. Default to 0.5.
+        min_n_trials:
+            A minimum number of complete trials to estimate the regret. Default to 20.
+        seed:
+            Seed for random number generator.
+
+    For further information about this evaluator, please refer to the following paper:
+
+    - `Automatic Termination for Hyperparameter Optimization <https://proceedings.mlr.press/v188/makarova22a.html>`__
+    """  # NOQA: E501
+
+    def __init__(
+        self,
+        top_trials_ratio: float = DEFAULT_TOP_TRIALS_RATIO,
+        min_n_trials: int = DEFAULT_MIN_N_TRIALS,
+        seed: int | None = None,
+    ) -> None:
+        self._top_trials_ratio = top_trials_ratio
+        self._min_n_trials = min_n_trials
+        self._log_prior = prior.default_log_prior
+        self._minimum_noise = prior.DEFAULT_MINIMUM_NOISE_VAR
+        self._optimize_n_samples = 2048
+        self._rng = LazyRandomState(seed)
+
+    def _get_top_n(
+        self, normalized_params: np.ndarray, values: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        assert len(normalized_params) == len(values)
+        n_trials = len(normalized_params)
+        top_n = np.clip(int(n_trials * self._top_trials_ratio), self._min_n_trials, n_trials)
+        top_n_val = np.partition(values, n_trials - top_n)[n_trials - top_n]
+        top_n_mask = values >= top_n_val
+        return normalized_params[top_n_mask], values[top_n_mask]
+
+    def evaluate(self, trials: list[FrozenTrial], study_direction: StudyDirection) -> float:
+        optuna_search_space = intersection_search_space(trials)
+        self._validate_input(trials, optuna_search_space)
+
+        complete_trials = [t for t in trials if t.state == TrialState.COMPLETE]
+
+        # _gp module assumes that optimization direction is maximization
+        sign = -1 if study_direction == StudyDirection.MINIMIZE else 1
+        values = np.array([t.value for t in complete_trials]) * sign
+        search_space = gp_search_space.SearchSpace(optuna_search_space)
+        normalized_params = search_space.get_normalized_params(complete_trials)
+        normalized_top_n_params, top_n_values = self._get_top_n(normalized_params, values)
+        top_n_values_mean = top_n_values.mean()
+        top_n_values_std = max(1e-10, top_n_values.std())
+        standarized_top_n_values = (top_n_values - top_n_values_mean) / top_n_values_std
+
+        gpr = gp.fit_kernel_params(
+            X=normalized_top_n_params,
+            Y=standarized_top_n_values,
+            is_categorical=search_space.is_categorical,
+            log_prior=self._log_prior,
+            minimum_noise=self._minimum_noise,
+            # TODO(contramundum53): Add option to specify this.
+            deterministic_objective=False,
+            # TODO(y0z): Add `kernel_params_cache` to speedup.
+            gpr_cache=None,
+        )
+
+        standardized_regret_bound = _compute_standardized_regret_bound(
+            gpr,
+            search_space,
+            normalized_top_n_params,
+            standarized_top_n_values,
+            rng=self._rng.rng,
+        )
+        return standardized_regret_bound * top_n_values_std  # regret bound
+
+    @classmethod
+    def _validate_input(
+        cls, trials: list[FrozenTrial], search_space: dict[str, BaseDistribution]
+    ) -> None:
+        if len([t for t in trials if t.state == TrialState.COMPLETE]) == 0:
+            raise ValueError(
+                "Because no trial has been completed yet, the regret bound cannot be evaluated."
+            )
+
+        if len(search_space) == 0:
+            raise ValueError(
+                "The intersection search space is empty. This condition is not supported by "
+                f"{cls.__name__}."
+            )
+
+
+@experimental_class("3.4.0")
+class BestValueStagnationEvaluator(BaseImprovementEvaluator):
+    """Evaluates the stagnation period of the best value in an optimization process.
+
+    This class is initialized with a maximum stagnation period (``max_stagnation_trials``)
+    and is designed to evaluate the remaining trials before reaching this maximum period
+    of allowed stagnation. If this remaining trials reach zero, the trial terminates.
+    Therefore, the default error evaluator is instantiated by ``StaticErrorEvaluator(const=0)``.
+
+    Args:
+        max_stagnation_trials:
+            The maximum number of trials allowed for stagnation.
+    """
+
+    def __init__(self, max_stagnation_trials: int = 30) -> None:
+        if max_stagnation_trials < 0:
+            raise ValueError("The maximum number of stagnant trials must not be negative.")
+        self._max_stagnation_trials = max_stagnation_trials
+
+    def evaluate(self, trials: list[FrozenTrial], study_direction: StudyDirection) -> float:
+        self._validate_input(trials)
+        is_maximize_direction = True if (study_direction == StudyDirection.MAXIMIZE) else False
+        trials = [t for t in trials if t.state == TrialState.COMPLETE]
+        current_step = len(trials) - 1
+
+        best_step = 0
+        for i, trial in enumerate(trials):
+            best_value = trials[best_step].value
+            current_value = trial.value
+            assert best_value is not None
+            assert current_value is not None
+            if is_maximize_direction and (best_value < current_value):
+                best_step = i
+            elif (not is_maximize_direction) and (best_value > current_value):
+                best_step = i
+
+        return self._max_stagnation_trials - (current_step - best_step)
+
+    @classmethod
+    def _validate_input(cls, trials: list[FrozenTrial]) -> None:
+        if len([t for t in trials if t.state == TrialState.COMPLETE]) == 0:
+            raise ValueError(
+                "Because no trial has been completed yet, the improvement cannot be evaluated."
+            )

--- a/package/callbacks/terminator/median_erroreval.py
+++ b/package/callbacks/terminator/median_erroreval.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from optuna._experimental import experimental_class
+from optuna.trial._state import TrialState
+
+from .erroreval import BaseErrorEvaluator
+
+
+if TYPE_CHECKING:
+    from optuna.study import StudyDirection
+    from optuna.trial import FrozenTrial
+
+    from .improvement.evaluator import BaseImprovementEvaluator
+
+
+@experimental_class("4.0.0")
+class MedianErrorEvaluator(BaseErrorEvaluator):
+    """An error evaluator that returns the ratio to initial median.
+
+    This error evaluator is introduced as a heuristics in the following paper:
+
+    - `A stopping criterion for Bayesian optimization by the gap of expected minimum simple
+      regrets <https://proceedings.mlr.press/v206/ishibashi23a.html>`__
+
+    Args:
+        paired_improvement_evaluator:
+            The ``improvement_evaluator`` instance which is set with this ``error_evaluator``.
+        warm_up_trials:
+            A parameter specifies the number of initial trials to be discarded before
+            the calculation of median. Default to 10.
+            In optuna, the first 10 trials are often random sampling.
+            The ``warm_up_trials`` can exclude them from the calculation.
+        n_initial_trials:
+            A parameter specifies the number of initial trials considered in the calculation of
+            median after ``warm_up_trials``. Default to 20.
+        threshold_ratio:
+            A parameter specifies the ratio between the threshold and initial median.
+            Default to 0.01.
+    """
+
+    def __init__(
+        self,
+        paired_improvement_evaluator: BaseImprovementEvaluator,
+        warm_up_trials: int = 10,
+        n_initial_trials: int = 20,
+        threshold_ratio: float = 0.01,
+    ) -> None:
+        if warm_up_trials < 0:
+            raise ValueError("`warm_up_trials` is expected to be a non-negative integer.")
+        if n_initial_trials <= 0:
+            raise ValueError("`n_initial_trials` is expected to be a positive integer.")
+        if threshold_ratio <= 0.0 or not np.isfinite(threshold_ratio):
+            raise ValueError("`threshold_ratio_to_initial_median` is expected to be a positive.")
+
+        self._paired_improvement_evaluator = paired_improvement_evaluator
+        self._warm_up_trials = warm_up_trials
+        self._n_initial_trials = n_initial_trials
+        self._threshold_ratio = threshold_ratio
+        self._threshold: float | None = None
+
+    def evaluate(
+        self,
+        trials: list[FrozenTrial],
+        study_direction: StudyDirection,
+    ) -> float:
+        if self._threshold is not None:
+            return self._threshold
+
+        trials = [trial for trial in trials if trial.state == TrialState.COMPLETE]
+        if len(trials) < (self._warm_up_trials + self._n_initial_trials):
+            return (
+                -sys.float_info.min
+            )  # Do not terminate. It assumes that improvement must non-negative.
+        trials.sort(key=lambda trial: trial.number)
+        criteria = []
+        for i in range(1, self._n_initial_trials + 1):
+            criteria.append(
+                self._paired_improvement_evaluator.evaluate(
+                    trials[self._warm_up_trials : self._warm_up_trials + i], study_direction
+                )
+            )
+        criteria.sort()
+        self._threshold = criteria[len(criteria) // 2]
+        assert self._threshold is not None
+        self._threshold = min(sys.float_info.max, self._threshold * self._threshold_ratio)
+        return self._threshold

--- a/package/callbacks/terminator/median_erroreval.py
+++ b/package/callbacks/terminator/median_erroreval.py
@@ -4,7 +4,6 @@ import sys
 from typing import TYPE_CHECKING
 
 import numpy as np
-from optuna._experimental import experimental_class
 from optuna.trial._state import TrialState
 
 from .erroreval import BaseErrorEvaluator
@@ -17,7 +16,6 @@ if TYPE_CHECKING:
     from .improvement.evaluator import BaseImprovementEvaluator
 
 
-@experimental_class("4.0.0")
 class MedianErrorEvaluator(BaseErrorEvaluator):
     """An error evaluator that returns the ratio to initial median.
 

--- a/package/callbacks/terminator/terminator.py
+++ b/package/callbacks/terminator/terminator.py
@@ -37,11 +37,10 @@ class Terminator(BaseTerminator):
     Args:
         improvement_evaluator:
             An evaluator object for assessing the room left for optimization. Defaults to a
-            :class:`~optuna.terminator.improvement.evaluator.RegretBoundEvaluator` object.
+            ``RegretBoundEvaluator`` object.
         error_evaluator:
             An evaluator for calculating the statistical error, e.g. cross-validation error.
-            Defaults to a :class:`~optuna.terminator.CrossValidationErrorEvaluator`
-            object.
+            Defaults to a ``CrossValidationErrorEvaluator`` object.
         min_n_trials:
             The minimum number of trials before termination is considered. Defaults to ``20``.
 
@@ -96,7 +95,7 @@ class Terminator(BaseTerminator):
                     break
 
     .. seealso::
-        Please refer to :class:`~optuna.terminator.TerminatorCallback` for how to use
+        Please refer to ``TerminatorCallback`` for how to use
         the terminator mechanism with the :func:`~optuna.study.Study.optimize` method.
 
     """

--- a/package/callbacks/terminator/terminator.py
+++ b/package/callbacks/terminator/terminator.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import abc
+
+from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
+from optuna._warnings import optuna_warn
+from optuna.study.study import Study
+from optuna.trial import TrialState
+
+from .erroreval import BaseErrorEvaluator
+from .erroreval import CrossValidationErrorEvaluator
+from .erroreval import StaticErrorEvaluator
+from .improvement.evaluator import BaseImprovementEvaluator
+from .improvement.evaluator import BestValueStagnationEvaluator
+from .improvement.evaluator import DEFAULT_MIN_N_TRIALS
+from .improvement.evaluator import RegretBoundEvaluator
+
+
+_DEPRECATION_WARNING_MESSAGE = _DEPRECATION_WARNING_TEMPLATE.format(
+    name="`optuna.terminator` module",
+    d_ver="4.9.0",
+    r_ver="6.0.0",
+)
+
+
+class BaseTerminator(metaclass=abc.ABCMeta):
+    """Base class for terminators."""
+
+    @abc.abstractmethod
+    def should_terminate(self, study: Study) -> bool:
+        pass
+
+
+class Terminator(BaseTerminator):
+    """Automatic stopping mechanism for Optuna studies.
+
+    This class implements an automatic stopping mechanism for Optuna studies, aiming to prevent
+    unnecessary computation. The study is terminated when the statistical error, e.g.
+    cross-validation error, exceeds the room left for optimization.
+
+    For further information about the algorithm, please refer to the following paper:
+
+    - `A. Makarova et al. Automatic termination for hyperparameter optimization.
+      <https://proceedings.mlr.press/v188/makarova22a.html>`__
+
+    Args:
+        improvement_evaluator:
+            An evaluator object for assessing the room left for optimization. Defaults to a
+            :class:`~optuna.terminator.improvement.evaluator.RegretBoundEvaluator` object.
+        error_evaluator:
+            An evaluator for calculating the statistical error, e.g. cross-validation error.
+            Defaults to a :class:`~optuna.terminator.CrossValidationErrorEvaluator`
+            object.
+        min_n_trials:
+            The minimum number of trials before termination is considered. Defaults to ``20``.
+
+    Raises:
+        ValueError: If ``min_n_trials`` is not a positive integer.
+
+    Example:
+
+        .. testcode::
+
+            import logging
+            import sys
+
+            from sklearn.datasets import load_wine
+            from sklearn.ensemble import RandomForestClassifier
+            from sklearn.model_selection import cross_val_score
+            from sklearn.model_selection import KFold
+
+            import optuna
+            from optuna.terminator import Terminator
+            from optuna.terminator import report_cross_validation_scores
+
+
+            study = optuna.create_study(direction="maximize")
+            terminator = Terminator()
+            min_n_trials = 20
+
+            while True:
+                trial = study.ask()
+
+                X, y = load_wine(return_X_y=True)
+
+                clf = RandomForestClassifier(
+                    max_depth=trial.suggest_int("max_depth", 2, 32),
+                    min_samples_split=trial.suggest_float("min_samples_split", 0, 1),
+                    criterion=trial.suggest_categorical("criterion", ("gini", "entropy")),
+                )
+
+                scores = cross_val_score(clf, X, y, cv=KFold(n_splits=5, shuffle=True))
+                report_cross_validation_scores(trial, scores)
+
+                value = scores.mean()
+                logging.info(f"Trial #{trial.number} finished with value {value}.")
+                study.tell(trial, value)
+
+                if trial.number > min_n_trials and terminator.should_terminate(study):
+                    logging.info("Terminated by Optuna Terminator!")
+                    break
+
+    .. seealso::
+        Please refer to :class:`~optuna.terminator.TerminatorCallback` for how to use
+        the terminator mechanism with the :func:`~optuna.study.Study.optimize` method.
+
+    """
+
+    def __init__(
+        self,
+        improvement_evaluator: BaseImprovementEvaluator | None = None,
+        error_evaluator: BaseErrorEvaluator | None = None,
+        min_n_trials: int = DEFAULT_MIN_N_TRIALS,
+    ) -> None:
+        optuna_warn(_DEPRECATION_WARNING_MESSAGE, FutureWarning)
+
+        if min_n_trials <= 0:
+            raise ValueError("`min_n_trials` is expected to be a positive integer.")
+
+        self._improvement_evaluator = improvement_evaluator or RegretBoundEvaluator()
+        self._error_evaluator = error_evaluator or self._initialize_error_evaluator()
+        self._min_n_trials = min_n_trials
+
+    def _initialize_error_evaluator(self) -> BaseErrorEvaluator:
+        if isinstance(self._improvement_evaluator, BestValueStagnationEvaluator):
+            return StaticErrorEvaluator(constant=0)
+        return CrossValidationErrorEvaluator()
+
+    def should_terminate(self, study: Study) -> bool:
+        """Judge whether the study should be terminated based on the reported values."""
+        trials = study.get_trials(states=[TrialState.COMPLETE])
+
+        if len(trials) < self._min_n_trials:
+            return False
+
+        improvement = self._improvement_evaluator.evaluate(
+            trials=study.trials,
+            study_direction=study.direction,
+        )
+
+        error = self._error_evaluator.evaluate(
+            trials=study.trials, study_direction=study.direction
+        )
+
+        should_terminate = improvement < error
+        return should_terminate

--- a/package/callbacks/terminator/terminator.py
+++ b/package/callbacks/terminator/terminator.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import abc
 
-from optuna._deprecated import _DEPRECATION_WARNING_TEMPLATE
-from optuna._warnings import optuna_warn
 from optuna.study.study import Study
 from optuna.trial import TrialState
 
@@ -14,13 +12,6 @@ from .improvement.evaluator import BaseImprovementEvaluator
 from .improvement.evaluator import BestValueStagnationEvaluator
 from .improvement.evaluator import DEFAULT_MIN_N_TRIALS
 from .improvement.evaluator import RegretBoundEvaluator
-
-
-_DEPRECATION_WARNING_MESSAGE = _DEPRECATION_WARNING_TEMPLATE.format(
-    name="`optuna.terminator` module",
-    d_ver="4.9.0",
-    r_ver="6.0.0",
-)
 
 
 class BaseTerminator(metaclass=abc.ABCMeta):
@@ -112,7 +103,6 @@ class Terminator(BaseTerminator):
         error_evaluator: BaseErrorEvaluator | None = None,
         min_n_trials: int = DEFAULT_MIN_N_TRIALS,
     ) -> None:
-        optuna_warn(_DEPRECATION_WARNING_MESSAGE, FutureWarning)
 
         if min_n_trials <= 0:
             raise ValueError("`min_n_trials` is expected to be a positive integer.")

--- a/package/callbacks/terminator/terminator.py
+++ b/package/callbacks/terminator/terminator.py
@@ -61,8 +61,12 @@ class Terminator(BaseTerminator):
             from sklearn.model_selection import KFold
 
             import optuna
-            from optuna.terminator import Terminator
-            from optuna.terminator import report_cross_validation_scores
+            import optunahub
+
+
+            module = optunahub.load_module("callbacks/terminator")
+            Terminator = module.Terminator
+            report_cross_validation_scores = module.report_cross_validation_scores
 
 
             study = optuna.create_study(direction="maximize")
@@ -103,7 +107,6 @@ class Terminator(BaseTerminator):
         error_evaluator: BaseErrorEvaluator | None = None,
         min_n_trials: int = DEFAULT_MIN_N_TRIALS,
     ) -> None:
-
         if min_n_trials <= 0:
             raise ValueError("`min_n_trials` is expected to be a positive integer.")
 


### PR DESCRIPTION
## Contributor Agreements

- [x] I agree to the contributor agreements.

## Motivation

Optuna's `optuna.terminator` module provides an automatic stopping mechanism that terminates a study once the estimated room for improvement falls below the statistical error. This PR ports it to OptunaHub so it can be loaded via `optunahub.load_module("callbacks/terminator")`.

## Description of the changes

- Add the `callbacks/terminator` package ported from `optuna.terminator`, including:
  - `TerminatorCallback`, `Terminator` / `BaseTerminator`
  - Improvement evaluators: `RegretBoundEvaluator`, `BestValueStagnationEvaluator`, `EMMREvaluator`
  - Error evaluators: `CrossValidationErrorEvaluator`, `StaticErrorEvaluator`, `MedianErrorEvaluator`, and `report_cross_validation_scores`
- Add `README.md`, `LICENSE`, and rewrite docstring examples to load the package through `optunahub`.

## TODO List towards PR Merge

- [x] Copy `./template/` to create your package
- [x] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [x] Fill out `README.md` in your package
- [x] Add import statements of your function or class names to be used in `__init__.py`
- [x] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [x] Apply the formatter based on the tips in `README.md`
- [x] Check whether your module works as intended based on the tips in `README.md`

---

This package is ported from `optuna.terminator`. The co-author list below was generated from the original Optuna history with:

```bash
git log --use-mailmap 6ace9ab96a2ac9a8a9e170d744e3737edb6b37ad \
  --format='Co-authored-by: %aN <%aE>' -- optuna/terminator \
  | sort -u
```