### PR TITLE
Accept per-metric pruners in `MultiMetricPruner`

### DIFF
--- a/package/pruners/multi_metric_pruner/README.md
+++ b/package/pruners/multi_metric_pruner/README.md
@@ -20,6 +20,8 @@ The pruning mode is selected via the `joint` argument:
 | Multi-metric | `True`  | `trial.report({"loss": v1, "acc": v2}, step)`                                      |
 | Per-metric   | `False` | `trial.report({"loss": v1, "acc": v2}, step)` or `trial.report({"loss": v}, step)` |
 
+When `metric_directions` has exactly one entry, `report` also accepts a plain `float` (i.e., the native Optuna `trial.report(value, step)` interface).
+
 ### Multi-metric mode (`joint=True`)
 
 All metrics are reported together as a dict at each step. The pruner ranks every trial at
@@ -71,6 +73,8 @@ def objective(trial: optuna.Trial) -> tuple[float, float]:
   - `joint`: If `True`, use multi-metric (Pareto-rank) mode. If `False`, use per-metric mode where each metric is evaluated independently.
 - `MultiMetricPrunerTrial(trial)`
   - `trial`: The trial object received in the objective function.
+  - `report(value, step)`: Report intermediate metric values at a given step. `value` is a dict mapping metric names to float values, or a plain `float` when `metric_directions` has exactly one entry.
+  - `should_prune(*, metric_name=None)`: Check whether the trial should be pruned. When `joint=True`, `metric_name` is ignored. When `joint=False`, passing `metric_name` restricts the check to that single metric; omitting it checks all metrics and prunes if any triggers the base pruner.
 
 ## Example
 

--- a/package/pruners/multi_metric_pruner/README.md
+++ b/package/pruners/multi_metric_pruner/README.md
@@ -31,6 +31,8 @@ intermediate values passed to the base pruner.
 Each metric is evaluated independently by the base pruner. Calling `should_prune()` with no
 argument checks all metrics and prunes if any one of them triggers the base pruner. You can
 also pass `metric_name` to `should_prune()` to restrict the check to a single metric.
+`base_pruner` can be a single pruner (shared across all metrics) or a dict mapping each
+metric name to its own pruner.
 This mode supports mixed-frequency reporting where different metrics are reported at
 different step intervals.
 
@@ -64,7 +66,7 @@ def objective(trial: optuna.Trial) -> tuple[float, float]:
 ## APIs
 
 - `MultiMetricPruner(base_pruner, *, metric_directions, joint)`
-  - `base_pruner`: Pruner that makes the actual pruning decision.
+  - `base_pruner`: Pruner that makes the actual pruning decision. Can also be a dict mapping metric names to pruners for per-metric pruning (only with `joint=False`). When a dict is given, its keys must exactly match the keys of `metric_directions`.
   - `metric_directions`: Mapping from metric name to direction (`"minimize"` / `"maximize"`).
   - `joint`: If `True`, use multi-metric (Pareto-rank) mode. If `False`, use per-metric mode where each metric is evaluated independently.
 - `MultiMetricPrunerTrial(trial)`
@@ -102,6 +104,19 @@ study = optuna.create_study(
     ),
 )
 study.optimize(objective, n_trials=30)
+```
+
+In per-metric mode, you can pass a dict of pruners to use a different pruner for each metric:
+
+```python
+pruner = MultiMetricPruner(
+    {
+        "loss": optuna.pruners.MedianPruner(n_startup_trials=3),
+        "acc": optuna.pruners.MedianPruner(n_startup_trials=5),
+    },
+    metric_directions={"loss": "minimize", "acc": "minimize"},
+    joint=False,
+)
 ```
 
 See [example.py](https://github.com/optuna/optunahub-registry/blob/main/package/pruners/multi_metric_pruner/example.py) for a full example including per-metric and mixed-frequency modes.

--- a/package/pruners/multi_metric_pruner/README.md
+++ b/package/pruners/multi_metric_pruner/README.md
@@ -15,10 +15,12 @@ and constructing a synthetic single-objective study for the wrapped base pruner 
 
 The pruning mode is selected via the `joint` argument:
 
+```md
 | Mode         | `joint` | `report` call (Example with `metric_names = ["loss", "acc"]`)                      |
 | ------------ | ------- | ---------------------------------------------------------------------------------- |
 | Multi-metric | `True`  | `trial.report({"loss": v1, "acc": v2}, step)`                                      |
 | Per-metric   | `False` | `trial.report({"loss": v1, "acc": v2}, step)` or `trial.report({"loss": v}, step)` |
+```
 
 When `metric_directions` has exactly one entry, `report` also accepts a plain `float` (i.e., the native Optuna `trial.report(value, step)` interface).
 

--- a/package/pruners/multi_metric_pruner/_pruner.py
+++ b/package/pruners/multi_metric_pruner/_pruner.py
@@ -195,7 +195,10 @@ class MultiMetricPruner(BasePruner):
 
     Args:
         base_pruner:
-            An Optuna pruner to delegate the actual pruning decision to.
+            An Optuna pruner to delegate the actual pruning decision to, or a dict
+            mapping metric names to pruners for per-metric pruning (only with
+            ``joint=False``). When a dict is given, its keys must exactly match the
+            keys of ``metric_directions``.
         metric_directions:
             A mapping from metric name to direction, e.g.
             ``{"loss": "minimize", "accuracy": "maximize"}``. All metrics reported via
@@ -237,7 +240,7 @@ class MultiMetricPruner(BasePruner):
 
     def __init__(
         self,
-        base_pruner: BasePruner,
+        base_pruner: BasePruner | dict[str, BasePruner],
         *,
         metric_directions: dict[str, str | StudyDirection],
         joint: bool,
@@ -255,6 +258,18 @@ class MultiMetricPruner(BasePruner):
                 f"`metric_directions` values must be 'minimize' or 'maximize', "
                 f"but got {metric_directions=}."
             )
+        if isinstance(base_pruner, dict):
+            if joint:
+                raise ValueError(
+                    "`base_pruner` must be a single BasePruner when `joint=True`, "
+                    "but got a dict. Per-metric pruners are only supported with `joint=False`."
+                )
+            if set(base_pruner.keys()) != set(metric_directions.keys()):
+                raise ValueError(
+                    f"When `base_pruner` is a dict, its keys must match `metric_directions` keys. "
+                    f"Got base_pruner keys {set(base_pruner.keys())} "
+                    f"vs metric_directions keys {set(metric_directions.keys())}."
+                )
         self._base_pruner = base_pruner
         self._joint = joint
         self._metric_directions = deepcopy(metric_directions)
@@ -277,6 +292,7 @@ class MultiMetricPruner(BasePruner):
             return False
 
         if self._joint:
+            assert isinstance(self._base_pruner, BasePruner)
             new_study, new_trial = _create_single_metric_study_and_trial_multi(
                 study, trial, self._metric_directions
             )
@@ -286,16 +302,21 @@ class MultiMetricPruner(BasePruner):
             metric_directions = self._metric_directions
             raise ValueError(f"{metric_name=} is not in {metric_directions=}.")
 
+        def _get_base_pruner(name: str) -> BasePruner:
+            if isinstance(self._base_pruner, dict):
+                return self._base_pruner[name]
+            return self._base_pruner
+
         if metric_name is None:
             for name, direction in self._metric_directions.items():
                 new_study, new_trial = _create_single_metric_study_and_trial_single(
                     study, trial, name, direction
                 )
-                if self._base_pruner.prune(new_study, new_trial):
+                if _get_base_pruner(name).prune(new_study, new_trial):
                     return True
             return False
         direction = self._metric_directions[metric_name]
         new_study, new_trial = _create_single_metric_study_and_trial_single(
             study, trial, metric_name, direction
         )
-        return self._base_pruner.prune(new_study, new_trial)
+        return _get_base_pruner(metric_name).prune(new_study, new_trial)

--- a/package/pruners/multi_metric_pruner/_pruner.py
+++ b/package/pruners/multi_metric_pruner/_pruner.py
@@ -212,7 +212,7 @@ class MultiMetricPruner(BasePruner):
             import optuna
             import optunahub
 
-            module = optunahub.load_local_module("pruners/multi_metric_pruner", registry_root="package/")
+            module = optunahub.load_module("pruners/multi_metric_pruner")
             MultiMetricPruner = module.MultiMetricPruner
             MultiMetricPrunerTrial = module.MultiMetricPrunerTrial
 

--- a/package/pruners/multi_metric_pruner/_trial.py
+++ b/package/pruners/multi_metric_pruner/_trial.py
@@ -19,7 +19,7 @@ def _cast_value_to_float(value: float) -> float:
     try:
         return float(value)
     except (TypeError, ValueError):
-        msg = f"`values` must be a dict of float but got value with type {type(value)}."
+        msg = f"`value` must be a dict of float but got value with type {type(value)}."
         raise TypeError(msg) from None
 
 
@@ -67,32 +67,33 @@ class MultiMetricPrunerTrial(optuna.Trial):
         assert name not in ("report", "should_prune")
         return getattr(self._trial, name)
 
-    def report(self, values: dict[str, float] | float, step: int) -> None:  # type: ignore[override]
+    def report(self, value: dict[str, float] | float, step: int) -> None:  # type: ignore[override]
         """Report intermediate metric values at a given step.
 
         Args:
-            values: A dict mapping metric names to float values, or a plain float when
+            value: A dict mapping metric names to float values, or a plain float when
                 ``metric_directions`` has exactly one entry (native Optuna interface).
                 All dict keys must be present in ``metric_directions``. Pass all metrics
                 for multi-metric (Pareto) mode, or a single-entry dict for per-metric mode.
             step: Step of the trial (e.g., training epoch).
         """
         step = _cast_step_to_int(step)
+        values = value  # `value` is just the Optuna compatible name.
         if not isinstance(values, dict):
             pruner = self._trial.study.pruner
             if isinstance(pruner, MultiMetricPruner) and len(pruner._metric_directions) == 1:
                 (metric_name,) = pruner._metric_directions
                 values = {metric_name: values}
             else:
-                raise TypeError(f"`values` must be a dict but got {type(values)}.")
+                raise TypeError(f"`value` must be a dict but got {type(values)}.")
         if len(values) == 0:
-            raise ValueError("`values` must have at least one entry.")
+            raise ValueError("`value` must have at least one entry.")
 
         pruner = self._trial.study.pruner
         if isinstance(pruner, MultiMetricPruner):
             unknown_keys = set(values.keys()) - set(pruner._metric_directions.keys())
             if unknown_keys:
-                raise ValueError(f"Got unknown metric names `{unknown_keys}` in `values`.")
+                raise ValueError(f"Got unknown metric names `{unknown_keys}` in `value`.")
             if not pruner._joint and len(values) > 1:
                 for k, v in values.items():
                     self.report({k: v}, step)

--- a/package/pruners/multi_metric_pruner/_trial.py
+++ b/package/pruners/multi_metric_pruner/_trial.py
@@ -67,18 +67,24 @@ class MultiMetricPrunerTrial(optuna.Trial):
         assert name not in ("report", "should_prune")
         return getattr(self._trial, name)
 
-    def report(self, values: dict[str, float], step: int) -> None:  # type: ignore[override]
+    def report(self, values: dict[str, float] | float, step: int) -> None:  # type: ignore[override]
         """Report intermediate metric values at a given step.
 
         Args:
-            values: A dict mapping metric names to float values. All keys must be present
-                in ``metric_directions``. Pass all metrics for multi-metric (Pareto) mode,
-                or a single-entry dict for per-metric mode.
+            values: A dict mapping metric names to float values, or a plain float when
+                ``metric_directions`` has exactly one entry (native Optuna interface).
+                All dict keys must be present in ``metric_directions``. Pass all metrics
+                for multi-metric (Pareto) mode, or a single-entry dict for per-metric mode.
             step: Step of the trial (e.g., training epoch).
         """
         step = _cast_step_to_int(step)
         if not isinstance(values, dict):
-            raise TypeError(f"`values` must be a dict but got {type(values)}.")
+            pruner = self._trial.study.pruner
+            if isinstance(pruner, MultiMetricPruner) and len(pruner._metric_directions) == 1:
+                (metric_name,) = pruner._metric_directions
+                values = {metric_name: values}
+            else:
+                raise TypeError(f"`values` must be a dict but got {type(values)}.")
         if len(values) == 0:
             raise ValueError("`values` must have at least one entry.")
 

--- a/package/pruners/multi_metric_pruner/example.py
+++ b/package/pruners/multi_metric_pruner/example.py
@@ -4,8 +4,7 @@ import optuna
 import optunahub
 
 
-# module = optunahub.load_module("pruners/multi_metric_pruner")
-module = optunahub.load_local_module("pruners/multi_metric_pruner", registry_root="package/")
+module = optunahub.load_module("pruners/multi_metric_pruner")
 MultiMetricPruner = module.MultiMetricPruner
 MultiMetricPrunerTrial = module.MultiMetricPrunerTrial
 

--- a/package/pruners/multi_metric_pruner/example.py
+++ b/package/pruners/multi_metric_pruner/example.py
@@ -70,7 +70,10 @@ study_per_metric = optuna.create_study(
     directions=["minimize", "maximize"],
     sampler=optuna.samplers.TPESampler(seed=42),
     pruner=MultiMetricPruner(
-        optuna.pruners.MedianPruner(n_startup_trials=3),
+        {
+            "loss": optuna.pruners.MedianPruner(n_startup_trials=3),
+            "acc": optuna.pruners.MedianPruner(n_startup_trials=5),
+        },
         metric_directions={"loss": "minimize", "acc": "maximize"},
         joint=False,
     ),
@@ -113,7 +116,10 @@ study_mixed = optuna.create_study(
     directions=["minimize", "minimize"],
     sampler=optuna.samplers.TPESampler(seed=42),
     pruner=MultiMetricPruner(
-        optuna.pruners.MedianPruner(n_startup_trials=3),
+        {
+            "train_loss": optuna.pruners.MedianPruner(n_startup_trials=3),
+            "val_loss": optuna.pruners.PercentilePruner(percentile=50.0, n_startup_trials=1),
+        },
         metric_directions={"train_loss": "minimize", "val_loss": "minimize"},
         joint=False,
     ),

--- a/package/pruners/multi_metric_pruner/tests/test_multi_metric_pruner.py
+++ b/package/pruners/multi_metric_pruner/tests/test_multi_metric_pruner.py
@@ -175,6 +175,25 @@ class TestMultiMetricPrunerTrialReport:
         with pytest.raises(TypeError, match="must be a dict"):
             wrapped.report([0.5, 0.8], step=0)  # type: ignore[arg-type]
 
+    def test_float_report_single_metric(self) -> None:
+        study = optuna.create_study(
+            direction="minimize",
+            pruner=MultiMetricPruner(
+                optuna.pruners.NopPruner(),
+                metric_directions={"loss": "minimize"},
+                joint=True,
+            ),
+        )
+        wrapped = _ask_wrapped(study)
+        wrapped.report(0.5, step=0)
+        attrs = wrapped._trial.user_attrs.get(_USER_ATTR_KEY, {})
+        assert attrs["0"]["loss"] == pytest.approx(0.5)
+
+    def test_float_report_multi_metric_raises(self) -> None:
+        wrapped = _ask_wrapped(_make_study())
+        with pytest.raises(TypeError, match="must be a dict"):
+            wrapped.report(0.5, step=0)  # type: ignore[arg-type]
+
     def test_empty_dict_raises(self) -> None:
         wrapped = _ask_wrapped(_make_study())
         with pytest.raises(ValueError, match="must have at least one entry"):

--- a/package/pruners/multi_metric_pruner/tests/test_multi_metric_pruner.py
+++ b/package/pruners/multi_metric_pruner/tests/test_multi_metric_pruner.py
@@ -32,16 +32,26 @@ class NeverPrunePruner(BasePruner):
 
 
 class CountingPruner(BasePruner):
-    def __init__(self) -> None:
+    def __init__(self, *, result: bool = False) -> None:
         self.call_count = 0
+        self._result = result
 
     def prune(self, study: optuna.Study, trial: optuna.trial.FrozenTrial) -> bool:
         self.call_count += 1
+        return self._result
+
+
+class TrackingPruner(BasePruner):
+    def __init__(self) -> None:
+        self.called = False
+
+    def prune(self, study: optuna.Study, trial: optuna.trial.FrozenTrial) -> bool:
+        self.called = True
         return False
 
 
 def _make_pruner(
-    base: BasePruner | None = None,
+    base: BasePruner | dict[str, BasePruner] | None = None,
     *,
     directions: dict | None = None,
     joint: bool = True,
@@ -69,7 +79,6 @@ def _add_complete_trial(
     values_per_step: dict[int, dict[str, float]],
     final_values: list[float],
 ) -> None:
-    """Add a finished trial with given intermediate values."""
     trial = study.ask()
     wrapped = MultiMetricPrunerTrial(trial)
     for step, vals in values_per_step.items():
@@ -77,18 +86,30 @@ def _add_complete_trial(
     study.tell(trial, final_values)
 
 
+def _make_pareto_study(
+    *,
+    metric_directions: dict[str, str],
+    study_directions: list[str] | None = None,
+) -> optuna.Study:
+    if study_directions is None:
+        study_directions = list(metric_directions.values())
+    pruner = MultiMetricPruner(
+        optuna.pruners.MedianPruner(n_startup_trials=0),
+        metric_directions=metric_directions,
+        joint=True,
+    )
+    return optuna.create_study(directions=study_directions, pruner=pruner)
+
+
 # ── MultiMetricPruner.__init__ ────────────────────────────────────────────────
 
 
 class TestMultiMetricPrunerInit:
-    def test_valid_joint_true(self) -> None:
-        pruner = _make_pruner(joint=True)
-        assert pruner._joint is True
+    @pytest.mark.parametrize("joint", [True, False])
+    def test_valid_construction(self, joint: bool) -> None:
+        pruner = _make_pruner(joint=joint)
+        assert pruner._joint is joint
         assert set(pruner._metric_directions) == {"loss", "acc"}
-
-    def test_valid_joint_false(self) -> None:
-        pruner = _make_pruner(joint=False)
-        assert pruner._joint is False
 
     def test_accepts_study_direction_enum(self) -> None:
         pruner = MultiMetricPruner(
@@ -145,38 +166,32 @@ class TestMultiMetricPrunerTrialReport:
         assert isinstance(attrs["0"]["loss"], float)
 
     def test_non_castable_value_raises(self) -> None:
-        study = _make_study()
-        wrapped = _ask_wrapped(study)
+        wrapped = _ask_wrapped(_make_study())
         with pytest.raises(TypeError, match="must be a dict of float"):
             wrapped.report({"loss": "not_a_number"}, step=0)  # type: ignore[arg-type,dict-item]
 
     def test_non_dict_raises(self) -> None:
-        study = _make_study()
-        wrapped = _ask_wrapped(study)
+        wrapped = _ask_wrapped(_make_study())
         with pytest.raises(TypeError, match="must be a dict"):
             wrapped.report([0.5, 0.8], step=0)  # type: ignore[arg-type]
 
     def test_empty_dict_raises(self) -> None:
-        study = _make_study()
-        wrapped = _ask_wrapped(study)
+        wrapped = _ask_wrapped(_make_study())
         with pytest.raises(ValueError, match="must have at least one entry"):
             wrapped.report({}, step=0)
 
     def test_negative_step_raises(self) -> None:
-        study = _make_study()
-        wrapped = _ask_wrapped(study)
+        wrapped = _ask_wrapped(_make_study())
         with pytest.raises(ValueError, match="cannot be negative"):
             wrapped.report({"loss": 0.5}, step=-1)
 
     def test_unknown_metric_raises(self) -> None:
-        study = _make_study()
-        wrapped = _ask_wrapped(study)
+        wrapped = _ask_wrapped(_make_study())
         with pytest.raises(ValueError, match="unknown metric"):
             wrapped.report({"unknown": 0.5}, step=0)
 
     def test_duplicate_warns_and_does_not_overwrite(self) -> None:
-        study = _make_study()
-        wrapped = _ask_wrapped(study)
+        wrapped = _ask_wrapped(_make_study())
         wrapped.report({"loss": 0.5}, step=0)
         with pytest.warns(Warning, match="already reported"):
             wrapped.report({"loss": 0.9}, step=0)
@@ -184,16 +199,13 @@ class TestMultiMetricPrunerTrialReport:
         assert attrs["0"]["loss"] == pytest.approx(0.5)
 
     def test_per_metric_splits_multi_dict(self) -> None:
-        """joint=False should still store all metrics, but split per-metric calls."""
-        study = _make_study(joint=False)
-        wrapped = _ask_wrapped(study)
+        wrapped = _ask_wrapped(_make_study(joint=False))
         wrapped.report({"loss": 0.5, "acc": 0.8}, step=0)
         attrs = wrapped._trial.user_attrs.get(_USER_ATTR_KEY, {})
         assert attrs["0"]["loss"] == pytest.approx(0.5)
         assert attrs["0"]["acc"] == pytest.approx(0.8)
 
     def test_partial_report_allowed(self) -> None:
-        """Reporting a subset of metric_directions keys must work (per-metric mode design intent)."""
         study = optuna.create_study(
             directions=["minimize", "minimize"],
             pruner=MultiMetricPruner(
@@ -203,39 +215,30 @@ class TestMultiMetricPrunerTrialReport:
             ),
         )
         wrapped = _ask_wrapped(study)
-        # Only train_loss reported — val_loss is omitted intentionally.
         wrapped.report({"train_loss": 0.5}, step=0)
         attrs = wrapped._trial.user_attrs.get(_USER_ATTR_KEY, {})
         assert "train_loss" in attrs["0"]
         assert "val_loss" not in attrs["0"]
 
     def test_step_stored_as_string_key(self) -> None:
-        study = _make_study()
-        wrapped = _ask_wrapped(study)
+        wrapped = _ask_wrapped(_make_study())
         wrapped.report({"loss": 0.3, "acc": 0.7}, step=5)
-        attrs = wrapped._trial.user_attrs.get(_USER_ATTR_KEY, {})
-        assert "5" in attrs
+        assert "5" in wrapped._trial.user_attrs.get(_USER_ATTR_KEY, {})
 
     def test_accumulates_values_across_steps(self) -> None:
-        study = _make_study()
-        wrapped = _ask_wrapped(study)
+        wrapped = _ask_wrapped(_make_study())
         for step in range(5):
             wrapped.report({"loss": float(step), "acc": float(step) * 2}, step=step)
-        attrs = wrapped._trial.user_attrs.get(_USER_ATTR_KEY, {})
-        assert len(attrs) == 5
+        assert len(wrapped._trial.user_attrs.get(_USER_ATTR_KEY, {})) == 5
 
     def test_getattr_delegates_to_inner_trial(self) -> None:
-        study = _make_study()
-        wrapped = _ask_wrapped(study)
+        wrapped = _ask_wrapped(_make_study())
         x = wrapped.suggest_float("x", 0.0, 1.0)
         assert 0.0 <= x <= 1.0
         assert "x" in wrapped.params
 
     def test_is_instance_of_optuna_trial(self) -> None:
-        """Integrations that check isinstance(trial, optuna.Trial) must accept the wrapper."""
-        study = _make_study()
-        wrapped = _ask_wrapped(study)
-        assert isinstance(wrapped, optuna.Trial)
+        assert isinstance(_ask_wrapped(_make_study()), optuna.Trial)
 
 
 # ── MultiMetricPrunerTrial.should_prune ──────────────────────────────────────
@@ -253,27 +256,17 @@ class TestMultiMetricPrunerTrialShouldPrune:
             directions=["minimize", "minimize"],
             pruner=_make_pruner(AlwaysPrunePruner()),
         )
-        wrapped = _ask_wrapped(study)
-        assert wrapped.should_prune() is False
+        assert _ask_wrapped(study).should_prune() is False
 
-    def test_joint_true_prunes_when_base_prunes(self) -> None:
+    @pytest.mark.parametrize("joint", [True, False])
+    def test_prunes_when_base_prunes(self, joint: bool) -> None:
         study = optuna.create_study(
             directions=["minimize", "minimize"],
-            pruner=_make_pruner(AlwaysPrunePruner(), joint=True),
+            pruner=_make_pruner(AlwaysPrunePruner(), joint=joint),
         )
         _add_complete_trial(study, {0: {"loss": 1.0, "acc": 1.0}}, [1.0, 1.0])
         wrapped = _ask_wrapped(study)
         wrapped.report({"loss": 2.0, "acc": 2.0}, step=0)
-        assert wrapped.should_prune() is True
-
-    def test_joint_false_prunes_when_any_metric_prunes(self) -> None:
-        study = optuna.create_study(
-            directions=["minimize", "minimize"],
-            pruner=_make_pruner(AlwaysPrunePruner(), joint=False),
-        )
-        _add_complete_trial(study, {0: {"loss": 1.0, "acc": 1.0}}, [1.0, 1.0])
-        wrapped = _ask_wrapped(study)
-        wrapped.report({"loss": 0.5, "acc": 0.5}, step=0)
         assert wrapped.should_prune() is True
 
     def test_joint_false_does_not_prune_when_base_never_prunes(self) -> None:
@@ -286,7 +279,6 @@ class TestMultiMetricPrunerTrialShouldPrune:
         assert wrapped.should_prune() is False
 
     def test_joint_false_with_metric_name_checks_only_that_metric(self) -> None:
-        """should_prune(metric_name=...) routes to per-metric prune."""
         study = optuna.create_study(
             directions=["minimize", "minimize"],
             pruner=_make_pruner(AlwaysPrunePruner(), joint=False),
@@ -297,30 +289,20 @@ class TestMultiMetricPrunerTrialShouldPrune:
         assert wrapped.should_prune(metric_name="loss") is True
 
     def test_joint_true_ignores_metric_name(self) -> None:
-        """joint=True should use Pareto ranking regardless of metric_name arg."""
         study = optuna.create_study(
             directions=["minimize", "minimize"],
             pruner=_make_pruner(NeverPrunePruner(), joint=True),
         )
         wrapped = _ask_wrapped(study)
         wrapped.report({"loss": 0.5, "acc": 0.5}, step=0)
-        # NeverPrunePruner means no pruning even with metric_name specified.
         assert wrapped.should_prune(metric_name="loss") is False
 
     def test_joint_true_metric_name_ignored_with_real_pruner(self) -> None:
-        """With joint=True and a real base pruner, metric_name must not change the outcome."""
-        pruner = MultiMetricPruner(
-            optuna.pruners.MedianPruner(n_startup_trials=0),
-            metric_directions={"loss": "minimize", "acc": "minimize"},
-            joint=True,
-        )
-        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
+        study = _make_pareto_study(metric_directions={"loss": "minimize", "acc": "minimize"})
         for val in [0.1, 0.2, 0.3, 0.4]:
             _add_complete_trial(study, {0: {"loss": val, "acc": val}}, [val, val])
-        trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
+        wrapped = _ask_wrapped(study)
         wrapped.report({"loss": 10.0, "acc": 10.0}, step=0)
-        # Dominated trial — all three call forms must agree and return True.
         assert wrapped.should_prune()
         assert wrapped.should_prune(metric_name="loss")
         assert wrapped.should_prune(metric_name="acc")
@@ -333,8 +315,7 @@ class TestMultiMetricPrunerPrune:
     def test_no_reports_returns_false(self) -> None:
         pruner = _make_pruner(AlwaysPrunePruner())
         study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
-        trial = study.ask()
-        frozen = trial._get_latest_trial()
+        frozen = study.ask()._get_latest_trial()
         assert pruner.prune(study, frozen) is False
 
     def test_joint_false_iterates_all_metrics_when_no_name(self) -> None:
@@ -342,285 +323,215 @@ class TestMultiMetricPrunerPrune:
         pruner = _make_pruner(base, joint=False)
         study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
         trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 0.5, "acc": 0.5}, step=0)
-        frozen = trial._get_latest_trial()
-        pruner.prune(study, frozen)
-        assert base.call_count == 2  # once per metric
+        MultiMetricPrunerTrial(trial).report({"loss": 0.5, "acc": 0.5}, step=0)
+        pruner.prune(study, trial._get_latest_trial())
+        assert base.call_count == 2
 
     def test_joint_false_short_circuits_on_first_prune(self) -> None:
-        call_count: list[int] = [0]
-
-        class FirstAlwaysPruner(BasePruner):
-            def prune(self, study: optuna.Study, trial: optuna.trial.FrozenTrial) -> bool:
-                call_count[0] += 1
-                return True  # always prune
-
-        pruner = _make_pruner(FirstAlwaysPruner(), joint=False)
+        base = CountingPruner(result=True)
+        pruner = _make_pruner(base, joint=False)
         study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
         trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 0.5, "acc": 0.5}, step=0)
-        frozen = trial._get_latest_trial()
-        result = pruner.prune(study, frozen)
-        assert result is True
-        assert call_count[0] == 1  # stopped after first True
+        MultiMetricPrunerTrial(trial).report({"loss": 0.5, "acc": 0.5}, step=0)
+        assert pruner.prune(study, trial._get_latest_trial()) is True
+        assert base.call_count == 1
 
     def test_joint_false_with_metric_name_calls_base_once(self) -> None:
         base = CountingPruner()
         pruner = _make_pruner(base, joint=False)
         study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
         trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 0.5, "acc": 0.5}, step=0)
-        frozen = trial._get_latest_trial()
-        pruner.prune(study, frozen, metric_name="loss")
+        MultiMetricPrunerTrial(trial).report({"loss": 0.5, "acc": 0.5}, step=0)
+        pruner.prune(study, trial._get_latest_trial(), metric_name="loss")
         assert base.call_count == 1
 
 
-# ── Pareto bonus (joint=True) ─────────────────────────────────────────────────
+# ── Pareto pruning (joint=True) ─────────────────────────────────────────────
 
 
-class TestParetoBonus:
-    def test_pareto_front_trial_not_pruned(self) -> None:
-        """A Pareto-dominant trial must not be pruned even when MedianPruner would prune it."""
-        # MedianPruner with n_startup_trials=0 prunes aggressively.
-        pruner = MultiMetricPruner(
-            optuna.pruners.MedianPruner(n_startup_trials=0),
-            metric_directions={"loss": "minimize", "acc": "minimize"},
-            joint=True,
+class TestParetoPruning:
+    @pytest.mark.parametrize(
+        "metric_dirs, completed_vals, completed_acc, current_vals, should_prune",
+        [
+            # Pareto-dominant trial (all minimize) → not pruned
+            (
+                {"loss": "minimize", "acc": "minimize"},
+                [5.0, 6.0, 7.0, 8.0],
+                None,
+                {"loss": 0.1, "acc": 0.1},
+                False,
+            ),
+            # Dominated trial (all minimize) → pruned
+            (
+                {"loss": "minimize", "acc": "minimize"},
+                [0.1, 0.2, 0.3, 0.4],
+                None,
+                {"loss": 10.0, "acc": 10.0},
+                True,
+            ),
+            # Mixed directions: bad loss, good acc → Pareto front → not pruned
+            (
+                {"loss": "minimize", "acc": "maximize"},
+                [2.0, 3.0, 4.0, 5.0],
+                0.1,
+                {"loss": 10.0, "acc": 0.9},
+                False,
+            ),
+            # Mixed directions: bad on both → dominated → pruned
+            (
+                {"loss": "minimize", "acc": "maximize"},
+                [0.1, 0.2, 0.3, 0.4],
+                0.9,
+                {"loss": 5.0, "acc": 0.1},
+                True,
+            ),
+        ],
+    )
+    def test_pareto_pruning_decision(
+        self,
+        metric_dirs: dict,
+        completed_vals: list,
+        completed_acc: float | None,
+        current_vals: dict,
+        should_prune: bool,
+    ) -> None:
+        study = _make_pareto_study(
+            metric_directions=metric_dirs,
+            study_directions=list(metric_dirs.values()),
         )
-        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
-        # Add completed trials with bad values (high Pareto rank).
-        for val in [5.0, 6.0, 7.0, 8.0]:
-            _add_complete_trial(study, {0: {"loss": val, "acc": val}}, [val, val])
-        # Current trial is clearly on the Pareto front (dominates all prior trials).
-        trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 0.1, "acc": 0.1}, step=0)
-        assert not wrapped.should_prune()
-
-    def test_dominated_trial_can_be_pruned(self) -> None:
-        """A trial dominated by others should be prunable."""
-        pruner = MultiMetricPruner(
-            optuna.pruners.MedianPruner(n_startup_trials=0),
-            metric_directions={"loss": "minimize", "acc": "minimize"},
-            joint=True,
-        )
-        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
-        # Add completed trials with good values.
-        for val in [0.1, 0.2, 0.3, 0.4]:
-            _add_complete_trial(study, {0: {"loss": val, "acc": val}}, [val, val])
-        # Current trial is dominated by all prior trials.
-        trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 10.0, "acc": 10.0}, step=0)
-        assert wrapped.should_prune()
-
-
-# ── Pareto with maximize direction ───────────────────────────────────────────
-
-
-class TestParetoWithMaximizeDirection:
-    def test_pareto_front_protected_with_maximize_metric(self) -> None:
-        """A trial that excels on the maximize metric is on the Pareto front → not pruned."""
-        pruner = MultiMetricPruner(
-            optuna.pruners.MedianPruner(n_startup_trials=0),
-            metric_directions={"loss": "minimize", "acc": "maximize"},
-            joint=True,
-        )
-        study = optuna.create_study(directions=["minimize", "maximize"], pruner=pruner)
-        # Completed trials: good loss, bad acc.
-        for val in [2.0, 3.0, 4.0, 5.0]:
-            _add_complete_trial(study, {0: {"loss": val, "acc": 0.1}}, [val, 0.1])
-        # Current: bad loss, good acc — neither side dominates the other → Pareto front.
-        trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 10.0, "acc": 0.9}, step=0)
-        assert not wrapped.should_prune()
-
-    def test_dominated_trial_pruned_with_maximize_metric(self) -> None:
-        """A trial worse on both minimize and maximize metrics is prunable."""
-        pruner = MultiMetricPruner(
-            optuna.pruners.MedianPruner(n_startup_trials=0),
-            metric_directions={"loss": "minimize", "acc": "maximize"},
-            joint=True,
-        )
-        study = optuna.create_study(directions=["minimize", "maximize"], pruner=pruner)
-        # Completed trials: good loss AND good acc.
-        for val in [0.1, 0.2, 0.3, 0.4]:
-            _add_complete_trial(study, {0: {"loss": val, "acc": 0.9}}, [val, 0.9])
-        # Current: bad loss AND bad acc → dominated by all completed trials.
-        trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 5.0, "acc": 0.1}, step=0)
-        assert wrapped.should_prune()
+        for val in completed_vals:
+            acc = completed_acc if completed_acc is not None else val
+            step_vals = {k: val if k == "loss" else acc for k in metric_dirs}
+            _add_complete_trial(study, {0: step_vals}, [val, acc])
+        wrapped = _ask_wrapped(study)
+        wrapped.report(current_vals, step=0)
+        assert wrapped.should_prune() == should_prune
 
 
 # ── Pareto rank changes across steps ─────────────────────────────────────────
 
 
 class TestParetoRankAcrossSteps:
-    def test_dominated_at_early_step_but_pareto_front_at_latest_not_pruned(self) -> None:
-        """A trial dominated at step 0 but Pareto-dominant at step 1 must not be pruned."""
-        pruner = MultiMetricPruner(
-            optuna.pruners.MedianPruner(n_startup_trials=0),
-            metric_directions={"loss": "minimize", "acc": "minimize"},
-            joint=True,
-        )
-        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
-        # Completed: strong at step 0, weak at step 1.
-        for _ in range(4):
-            _add_complete_trial(
-                study,
+    @pytest.mark.parametrize(
+        "completed_steps, current_steps, expected_not_pruned",
+        [
+            # Dominated at step 0, dominant at step 1 → not pruned
+            (
                 {0: {"loss": 0.1, "acc": 0.1}, 1: {"loss": 5.0, "acc": 5.0}},
-                [0.1, 0.1],
-            )
-        # Current: weak at step 0 (dominated), dominant at step 1.
-        trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 5.0, "acc": 5.0}, step=0)
-        wrapped.report({"loss": 0.01, "acc": 0.01}, step=1)
-        assert not wrapped.should_prune()
-
-    def test_pareto_dominance_at_any_step_protects_from_pruning(self) -> None:
-        """A trial Pareto-dominant at step 0 stays protected even after degrading at step 1.
-
-        MedianPruner uses the trial's best intermediate value across all steps, so a trial
-        that achieves a very negative synthetic rank at step 0 (-1.0) keeps that protection
-        regardless of what happens at the latest step.
-        """
-        pruner = MultiMetricPruner(
-            optuna.pruners.MedianPruner(n_startup_trials=0),
-            metric_directions={"loss": "minimize", "acc": "minimize"},
-            joint=True,
-        )
-        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
-        # Completed: weak at step 0, strong at step 1.
-        for _ in range(4):
-            _add_complete_trial(
-                study,
+                [(0, 5.0, 5.0), (1, 0.01, 0.01)],
+                True,
+            ),
+            # Dominant at step 0, dominated at step 1 → still protected
+            (
                 {0: {"loss": 5.0, "acc": 5.0}, 1: {"loss": 0.1, "acc": 0.1}},
-                [0.1, 0.1],
-            )
-        # Current: dominant at step 0 (synthetic rank -1.0), then dominated at step 1.
-        # The best-over-steps value is -1.0, which is below the median → not pruned.
-        trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 0.01, "acc": 0.01}, step=0)
-        wrapped.report({"loss": 10.0, "acc": 10.0}, step=1)
-        assert not wrapped.should_prune()
+                [(0, 0.01, 0.01), (1, 10.0, 10.0)],
+                True,
+            ),
+        ],
+    )
+    def test_rank_across_steps(
+        self,
+        completed_steps: dict,
+        current_steps: list,
+        expected_not_pruned: bool,
+    ) -> None:
+        study = _make_pareto_study(metric_directions={"loss": "minimize", "acc": "minimize"})
+        for _ in range(4):
+            _add_complete_trial(study, completed_steps, [0.1, 0.1])
+        wrapped = _ask_wrapped(study)
+        for step, loss, acc in current_steps:
+            wrapped.report({"loss": loss, "acc": acc}, step=step)
+        assert (not wrapped.should_prune()) is expected_not_pruned
 
 
 # ── Tie-break bonus integration ───────────────────────────────────────────────
 
 
 class TestTieBreakBonusIntegration:
-    """Verify that HV-contribution tie-breaking within a shared Pareto rank affects pruning.
-
-    Setup: one completed trial at rank 0 ([1,1]) anchors the non-dominated front.
-    Five identical rank-1 completed trials create a majority at a known synthetic rank range.
-    The current trial is also at rank 1 but differs in HV contribution, so the tie-break
-    bonus is either -0.5 (high contribution → lower synthetic rank → not pruned) or -0.1
-    (low contribution → higher synthetic rank → pruned) relative to the median.
-    """
-
-    def test_high_hv_contribution_not_pruned(self) -> None:
-        # Completed rank-1 trials: 5×[3,3] — lower HV contribution than [2,4].
-        # Their synthetic ranks fill [0.58, …, 0.90]; median ≈ 0.70.
-        # Current [2,4]: bonus -0.5 → synthetic rank 0.50 < median → not pruned.
-        pruner = MultiMetricPruner(
-            optuna.pruners.MedianPruner(n_startup_trials=0),
-            metric_directions={"loss": "minimize", "acc": "minimize"},
-            joint=True,
-        )
-        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
+    @pytest.mark.parametrize(
+        "rank1_vals, current_vals, expected_not_pruned",
+        [
+            # High HV contribution → not pruned
+            ({"loss": 3.0, "acc": 3.0}, {"loss": 2.0, "acc": 4.0}, True),
+            # Low HV contribution → pruned
+            ({"loss": 2.0, "acc": 4.0}, {"loss": 3.0, "acc": 3.0}, False),
+        ],
+    )
+    def test_hv_contribution_affects_pruning(
+        self, rank1_vals: dict, current_vals: dict, expected_not_pruned: bool
+    ) -> None:
+        study = _make_pareto_study(metric_directions={"loss": "minimize", "acc": "minimize"})
         _add_complete_trial(study, {0: {"loss": 1.0, "acc": 1.0}}, [1.0, 1.0])
         for _ in range(5):
-            _add_complete_trial(study, {0: {"loss": 3.0, "acc": 3.0}}, [3.0, 3.0])
-        trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 2.0, "acc": 4.0}, step=0)
-        assert not wrapped.should_prune()
-
-    def test_low_hv_contribution_pruned(self) -> None:
-        # Completed rank-1 trials: 5×[2,4] — higher HV contribution than [3,3].
-        # Their synthetic ranks fill [0.50, …, 0.82]; median ≈ 0.62.
-        # Current [3,3]: bonus -0.1 → synthetic rank 0.90 > median → pruned.
-        pruner = MultiMetricPruner(
-            optuna.pruners.MedianPruner(n_startup_trials=0),
-            metric_directions={"loss": "minimize", "acc": "minimize"},
-            joint=True,
-        )
-        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
-        _add_complete_trial(study, {0: {"loss": 1.0, "acc": 1.0}}, [1.0, 1.0])
-        for _ in range(5):
-            _add_complete_trial(study, {0: {"loss": 2.0, "acc": 4.0}}, [2.0, 4.0])
-        trial = study.ask()
-        wrapped = MultiMetricPrunerTrial(trial)
-        wrapped.report({"loss": 3.0, "acc": 3.0}, step=0)
-        assert wrapped.should_prune()
+            _add_complete_trial(
+                study, {0: rank1_vals}, [rank1_vals["loss"], rank1_vals["acc"]]
+            )
+        wrapped = _ask_wrapped(study)
+        wrapped.report(current_vals, step=0)
+        assert (not wrapped.should_prune()) is expected_not_pruned
 
 
-# ── End-to-end tests from example.py ─────────────────────────────────────────
+# ── End-to-end tests ─────────────────────────────────────────────────────────
+
+
+_E2E_CONFIGS = [
+    pytest.param(
+        True,
+        {"loss": "minimize", "acc": "minimize"},
+        ["minimize", "minimize"],
+        optuna.pruners.MedianPruner(n_startup_trials=3),
+        id="joint",
+    ),
+    pytest.param(
+        False,
+        {"loss": "minimize", "acc": "maximize"},
+        ["minimize", "maximize"],
+        optuna.pruners.MedianPruner(n_startup_trials=3),
+        id="per-metric",
+    ),
+    pytest.param(
+        False,
+        {"loss": "minimize", "acc": "maximize"},
+        ["minimize", "maximize"],
+        {
+            "loss": optuna.pruners.MedianPruner(n_startup_trials=3),
+            "acc": optuna.pruners.MedianPruner(n_startup_trials=5),
+        },
+        id="per-metric-dict",
+    ),
+]
 
 
 class TestEndToEnd:
-    def test_multi_metric_mode(self) -> None:
-        """Mode 1: joint=True with Pareto-ranked intermediate values."""
-
+    @pytest.mark.parametrize("joint, metric_dirs, study_dirs, base_pruner", _E2E_CONFIGS)
+    def test_optimize_with_pruning(
+        self,
+        joint: bool,
+        metric_dirs: dict,
+        study_dirs: list,
+        base_pruner: BasePruner | dict[str, BasePruner],
+    ) -> None:
         def objective(trial: optuna.Trial) -> tuple[float, float]:
             mmt = MultiMetricPrunerTrial(trial)
             x = mmt.suggest_float("x", -5.0, 5.0)
             for step in range(10):
-                mmt.report({"loss": (x - step * 0.1) ** 2, "acc": (x + step * 0.1) ** 2}, step)
+                mmt.report(
+                    {"loss": (x - step * 0.1) ** 2, "acc": (x + step * 0.1) ** 2}, step
+                )
                 if mmt.should_prune():
                     raise optuna.TrialPruned()
             return x**2, (x - 2.0) ** 2
 
         study = optuna.create_study(
-            directions=["minimize", "minimize"],
+            directions=study_dirs,
             sampler=optuna.samplers.TPESampler(seed=42),
-            pruner=MultiMetricPruner(
-                optuna.pruners.MedianPruner(n_startup_trials=3),
-                metric_directions={"loss": "minimize", "acc": "minimize"},
-                joint=True,
-            ),
+            pruner=MultiMetricPruner(base_pruner, metric_directions=metric_dirs, joint=joint),
         )
-        study.optimize(objective, n_trials=30)
-        assert len(study.trials) == 30
-        assert any(t.state == TrialState.PRUNED for t in study.trials)
-
-    def test_per_metric_mode(self) -> None:
-        """Mode 2: joint=False, each metric evaluated independently."""
-
-        def objective(trial: optuna.Trial) -> tuple[float, float]:
-            mmt = MultiMetricPrunerTrial(trial)
-            x = mmt.suggest_float("x", -5.0, 5.0)
-            for step in range(10):
-                loss = (x - step * 0.1) ** 2
-                acc = 1.0 / (1.0 + (x + step * 0.1) ** 2)
-                mmt.report({"loss": loss, "acc": acc}, step)
-                if mmt.should_prune():
-                    raise optuna.TrialPruned()
-            return x**2, 1.0 / (1.0 + (x - 2.0) ** 2)
-
-        study = optuna.create_study(
-            directions=["minimize", "maximize"],
-            sampler=optuna.samplers.TPESampler(seed=42),
-            pruner=MultiMetricPruner(
-                optuna.pruners.MedianPruner(n_startup_trials=3),
-                metric_directions={"loss": "minimize", "acc": "maximize"},
-                joint=False,
-            ),
-        )
-        study.optimize(objective, n_trials=30)
-        assert len(study.trials) == 30
+        study.optimize(objective, n_trials=15)
+        assert len(study.trials) == 15
         assert any(t.state == TrialState.PRUNED for t in study.trials)
 
     def test_mixed_frequency_mode(self) -> None:
-        """Mode 3: metrics reported at different step intervals."""
-
         def objective(trial: optuna.Trial) -> tuple[float, float]:
             mmt = MultiMetricPrunerTrial(trial)
             x = mmt.suggest_float("x", -5.0, 5.0)
@@ -643,18 +554,15 @@ class TestEndToEnd:
                 joint=False,
             ),
         )
-        study.optimize(objective, n_trials=30)
-        assert len(study.trials) == 30
+        study.optimize(objective, n_trials=15)
+        assert len(study.trials) == 15
         assert any(t.state == TrialState.PRUNED for t in study.trials)
 
     def test_per_metric_coexists_with_partial_reports(self) -> None:
-        """Per-metric mode: reporting a subset of metric_directions must not error."""
-
         def objective(trial: optuna.Trial) -> tuple[float, float]:
             mmt = MultiMetricPrunerTrial(trial)
             x = mmt.suggest_float("x", -5.0, 5.0)
             for step in range(5):
-                # Only train_loss is reported; val_loss is never reported.
                 mmt.report({"train_loss": (x - step * 0.1) ** 2}, step)
                 if mmt.should_prune(metric_name="train_loss"):
                     raise optuna.TrialPruned()
@@ -678,48 +586,31 @@ class TestEndToEnd:
 
 class TestFastNonDominationRank:
     def test_empty_returns_empty(self) -> None:
-        result = _fast_non_domination_rank(np.empty((0, 2), dtype=float))
-        assert len(result) == 0
+        assert len(_fast_non_domination_rank(np.empty((0, 2), dtype=float))) == 0
 
     def test_single_point_rank_zero(self) -> None:
-        ranks = _fast_non_domination_rank(np.array([[1.0, 2.0]]))
-        assert ranks[0] == 0
+        assert _fast_non_domination_rank(np.array([[1.0, 2.0]]))[0] == 0
 
     def test_dominated_point_has_higher_rank(self) -> None:
-        # [1, 1] dominates [2, 2]
         ranks = _fast_non_domination_rank(np.array([[1.0, 1.0], [2.0, 2.0]]))
         assert ranks[0] < ranks[1]
 
     def test_pareto_points_same_rank(self) -> None:
-        # Neither [1, 2] nor [2, 1] dominates the other.
         ranks = _fast_non_domination_rank(np.array([[1.0, 2.0], [2.0, 1.0]]))
         assert ranks[0] == ranks[1] == 0
 
     def test_three_points_two_fronts(self) -> None:
-        # [1, 3] and [3, 1] are on rank-0 front; [4, 4] is rank 1.
         ranks = _fast_non_domination_rank(np.array([[1.0, 3.0], [3.0, 1.0], [4.0, 4.0]]))
-        assert ranks[0] == 0
-        assert ranks[1] == 0
-        assert ranks[2] == 1
+        assert ranks[0] == 0 and ranks[1] == 0 and ranks[2] == 1
 
     def test_single_objective_ranks_by_value(self) -> None:
-        values = np.array([[3.0], [1.0], [2.0]])
-        ranks = _fast_non_domination_rank(values)
-        # 1.0 -> rank 0, 2.0 -> rank 1, 3.0 -> rank 2
-        assert ranks[1] == 0
-        assert ranks[2] == 1
-        assert ranks[0] == 2
+        ranks = _fast_non_domination_rank(np.array([[3.0], [1.0], [2.0]]))
+        assert ranks[1] == 0 and ranks[2] == 1 and ranks[0] == 2
 
     def test_three_objectives(self) -> None:
-        # [1,1,1] dominates all others.
-        # [1,2,2] and [2,1,2] dominate [2,2,2] but not each other → rank 1.
-        # [2,2,2] is dominated by all → rank 2.
         values = np.array([[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [1.0, 2.0, 2.0], [2.0, 1.0, 2.0]])
         ranks = _fast_non_domination_rank(values)
-        assert ranks[0] == 0  # [1,1,1]: sole Pareto front
-        assert ranks[2] == 1  # [1,2,2]: rank 1
-        assert ranks[3] == 1  # [2,1,2]: rank 1
-        assert ranks[1] == 2  # [2,2,2]: dominated by all others
+        assert ranks[0] == 0 and ranks[2] == 1 and ranks[3] == 1 and ranks[1] == 2
 
 
 # ── _argsort_by_hv_contribution ───────────────────────────────────────────────
@@ -735,56 +626,44 @@ class TestArgsortByHvContribution:
     def test_is_a_permutation(self, loss_vals: list) -> None:
         lvals = np.array(loss_vals)
         ref = np.full(lvals.shape[1], 5.0)
-        order = _argsort_by_hv_contribution(lvals, ref)
-        assert sorted(order.tolist()) == list(range(len(lvals)))
+        assert sorted(_argsort_by_hv_contribution(lvals, ref).tolist()) == list(range(len(lvals)))
 
     @pytest.mark.parametrize("loss_vals", _HV_LOSS_VALS)
     def test_prefix_matches_greedy_selection(self, loss_vals: list) -> None:
-        # The first k of the order must be exactly the greedy best-k subset that the selector
-        # returns. This pins the order to genuine HV-contribution order for every prefix.
         lvals = np.array(loss_vals)
-        n = len(lvals)
         ref = np.full(lvals.shape[1], 5.0)
-        all_indices = np.arange(n)
         order = _argsort_by_hv_contribution(lvals, ref)
-        for k in range(1, n):
-            greedy_best_k = set(_solve_hssp(lvals, all_indices, k, ref).tolist())
+        for k in range(1, len(lvals)):
+            greedy_best_k = set(_solve_hssp(lvals, np.arange(len(lvals)), k, ref).tolist())
             assert set(order[:k].tolist()) == greedy_best_k
 
     def test_full_set_is_greedy_unlike_solve_hssp(self) -> None:
-        # `_solve_hssp` short-circuits the full subset to original order; the helper must not.
         lvals = np.array([[0.0, 3.0], [1.0, 1.0], [3.0, 0.0], [2.0, 2.0], [4.0, 4.0]])
         ref = np.array([5.0, 5.0])
         order = _argsort_by_hv_contribution(lvals, ref)
-        # [1,1] is the largest single contributor, [4,4] the smallest.
-        assert order[0] == 1
-        assert order[-1] == 4
-        assert _solve_hssp(lvals, np.arange(5), 5, ref).tolist() == [0, 1, 2, 3, 4]  # original
+        assert order[0] == 1 and order[-1] == 4
+        assert _solve_hssp(lvals, np.arange(5), 5, ref).tolist() == [0, 1, 2, 3, 4]
 
     def test_duplicates_are_tied_adjacent_group(self) -> None:
-        # Rows 1 and 3 are identical, so they share a contribution and must be adjacent, and the
-        # unique groups must keep greedy order.
         lvals = np.array([[0.0, 3.0], [1.0, 1.0], [3.0, 0.0], [1.0, 1.0], [4.0, 4.0]])
         ref = np.array([5.0, 5.0])
         order = _argsort_by_hv_contribution(lvals, ref).tolist()
-        assert abs(order.index(1) - order.index(3)) == 1  # tied pair adjacent
-        # Group order matches the order of the unique representatives.
-        uniq = np.array([[0.0, 3.0], [1.0, 1.0], [3.0, 0.0], [4.0, 4.0]])
-        uniq_order = _argsort_by_hv_contribution(uniq, ref).tolist()
-        assert uniq_order[0] == 1  # [1,1] group first
+        assert abs(order.index(1) - order.index(3)) == 1
+        uniq_order = _argsort_by_hv_contribution(
+            np.array([[0.0, 3.0], [1.0, 1.0], [3.0, 0.0], [4.0, 4.0]]), ref
+        ).tolist()
+        assert uniq_order[0] == 1
 
     @pytest.mark.parametrize(
         "loss_vals, expected",
         [
-            ([[1.0, 2.0]], [0]),  # single point
-            ([[2.0, 2.0], [1.0, 1.0]], [1, 0]),  # dominated point goes last
-            ([[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]], [0, 1, 2]),  # all tied
+            ([[1.0, 2.0]], [0]),
+            ([[2.0, 2.0], [1.0, 1.0]], [1, 0]),
+            ([[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]], [0, 1, 2]),
         ],
     )
     def test_edge_cases(self, loss_vals: list, expected: list) -> None:
-        lvals = np.array(loss_vals)
-        ref = np.array([5.0, 5.0])
-        assert _argsort_by_hv_contribution(lvals, ref).tolist() == expected
+        assert _argsort_by_hv_contribution(np.array(loss_vals), np.array([5.0, 5.0])).tolist() == expected
 
 
 # ── _tie_break ────────────────────────────────────────────────────────────────
@@ -792,30 +671,117 @@ class TestArgsortByHvContribution:
 
 class TestTieBreak:
     def test_current_trial_best_in_rank_gets_largest_bonus(self) -> None:
-        # Regression: the current trial (last index) used to be pinned to a 0.0 bonus. When it is
-        # the strongest HV contributor in its rank it must now get the most negative bonus.
         ranks = np.array([1, 1, 1])
-        lvals = np.array([[0.0, 4.0], [4.0, 0.0], [2.0, 2.0]])  # current [2,2] dominates the box
+        lvals = np.array([[0.0, 4.0], [4.0, 0.0], [2.0, 2.0]])
         indices, bonuses = _tie_break(lvals, ranks)
         bonus_of = dict(zip(indices.tolist(), bonuses.tolist()))
         assert bonus_of[2] == pytest.approx(-0.5)
         assert bonus_of[2] == min(bonuses)
 
-    def test_current_trial_weakest_in_rank_gets_zero_bonus(self) -> None:
+    def test_current_trial_weakest_in_rank_gets_smallest_bonus(self) -> None:
         ranks = np.array([1, 1, 1])
-        lvals = np.array([[1.0, 3.0], [3.0, 1.0], [0.0, 4.0]])  # current [0,4] is the thin sliver
+        lvals = np.array([[1.0, 3.0], [3.0, 1.0], [0.0, 4.0]])
         indices, bonuses = _tie_break(lvals, ranks)
-        bonus_of = dict(zip(indices.tolist(), bonuses.tolist()))
-        assert bonus_of[2] == pytest.approx(-0.1)
+        assert dict(zip(indices.tolist(), bonuses.tolist()))[2] == pytest.approx(-0.1)
 
     def test_bonuses_bounded(self) -> None:
-        ranks = np.array([1, 1, 1])
-        lvals = np.array([[0.0, 4.0], [4.0, 0.0], [2.0, 2.0]])
-        _, bonuses = _tie_break(lvals, ranks)
+        _, bonuses = _tie_break(
+            np.array([[0.0, 4.0], [4.0, 0.0], [2.0, 2.0]]), np.array([1, 1, 1])
+        )
         assert np.all(bonuses >= -0.5) and np.all(bonuses <= 0.0)
 
     def test_single_in_rank_gets_zero_bonus(self) -> None:
-        lvals = np.array([[0.0, 4.0], [4.0, 0.0], [2.0, 2.0]])
-        indices, bonuses = _tie_break(lvals, np.array([0, 2, 1]))
-        assert bonuses.tolist() == [0.0]
-        assert indices.tolist() == [2]
+        indices, bonuses = _tie_break(
+            np.array([[0.0, 4.0], [4.0, 0.0], [2.0, 2.0]]), np.array([0, 2, 1])
+        )
+        assert bonuses.tolist() == [0.0] and indices.tolist() == [2]
+
+
+# ── Per-metric dict base_pruner ──────────────────────────────────────────────
+
+
+class TestDictBasePruner:
+    def test_dict_base_pruner_joint_true_raises(self) -> None:
+        with pytest.raises(ValueError, match="single BasePruner when `joint=True`"):
+            MultiMetricPruner(
+                {"loss": optuna.pruners.NopPruner(), "acc": optuna.pruners.NopPruner()},
+                metric_directions={"loss": "minimize", "acc": "minimize"},
+                joint=True,
+            )
+
+    @pytest.mark.parametrize(
+        "pruner_dict",
+        [
+            {"loss": optuna.pruners.NopPruner()},
+            {
+                "loss": optuna.pruners.NopPruner(),
+                "acc": optuna.pruners.NopPruner(),
+                "extra": optuna.pruners.NopPruner(),
+            },
+        ],
+        ids=["missing-key", "extra-key"],
+    )
+    def test_dict_base_pruner_keys_mismatch_raises(self, pruner_dict: dict) -> None:
+        with pytest.raises(ValueError, match="keys must match"):
+            MultiMetricPruner(
+                pruner_dict,
+                metric_directions={"loss": "minimize", "acc": "minimize"},
+                joint=False,
+            )
+
+    def test_dict_base_pruner_valid(self) -> None:
+        pruner = MultiMetricPruner(
+            {"loss": optuna.pruners.NopPruner(), "acc": optuna.pruners.NopPruner()},
+            metric_directions={"loss": "minimize", "acc": "minimize"},
+            joint=False,
+        )
+        assert isinstance(pruner._base_pruner, dict)
+
+    def test_dict_base_pruner_routes_per_metric(self) -> None:
+        loss_pruner, acc_pruner = TrackingPruner(), TrackingPruner()
+        pruner = MultiMetricPruner(
+            {"loss": loss_pruner, "acc": acc_pruner},
+            metric_directions={"loss": "minimize", "acc": "minimize"},
+            joint=False,
+        )
+        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
+        trial = study.ask()
+        MultiMetricPrunerTrial(trial).report({"loss": 0.5, "acc": 0.8}, step=0)
+        pruner.prune(study, trial._get_latest_trial())
+        assert loss_pruner.called and acc_pruner.called
+
+    def test_dict_base_pruner_with_metric_name(self) -> None:
+        loss_pruner, acc_pruner = TrackingPruner(), TrackingPruner()
+        pruner = MultiMetricPruner(
+            {"loss": loss_pruner, "acc": acc_pruner},
+            metric_directions={"loss": "minimize", "acc": "minimize"},
+            joint=False,
+        )
+        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
+        trial = study.ask()
+        MultiMetricPrunerTrial(trial).report({"loss": 0.5}, step=0)
+        pruner.prune(study, trial._get_latest_trial(), metric_name="loss")
+        assert loss_pruner.called and not acc_pruner.called
+
+    def test_dict_base_pruner_prunes_when_one_metric_triggers(self) -> None:
+        pruner = MultiMetricPruner(
+            {"loss": AlwaysPrunePruner(), "acc": NeverPrunePruner()},
+            metric_directions={"loss": "minimize", "acc": "minimize"},
+            joint=False,
+        )
+        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
+        _add_complete_trial(study, {0: {"loss": 1.0, "acc": 1.0}}, [1.0, 1.0])
+        wrapped = _ask_wrapped(study)
+        wrapped.report({"loss": 0.5, "acc": 0.5}, step=0)
+        assert wrapped.should_prune() is True
+
+    def test_dict_base_pruner_does_not_prune_when_none_triggers(self) -> None:
+        pruner = MultiMetricPruner(
+            {"loss": NeverPrunePruner(), "acc": NeverPrunePruner()},
+            metric_directions={"loss": "minimize", "acc": "minimize"},
+            joint=False,
+        )
+        study = optuna.create_study(directions=["minimize", "minimize"], pruner=pruner)
+        wrapped = _ask_wrapped(study)
+        wrapped.report({"loss": 0.5, "acc": 0.5}, step=0)
+        assert wrapped.should_prune() is False

--- a/package/pruners/multi_metric_pruner/tests/test_multi_metric_pruner.py
+++ b/package/pruners/multi_metric_pruner/tests/test_multi_metric_pruner.py
@@ -463,9 +463,7 @@ class TestTieBreakBonusIntegration:
         study = _make_pareto_study(metric_directions={"loss": "minimize", "acc": "minimize"})
         _add_complete_trial(study, {0: {"loss": 1.0, "acc": 1.0}}, [1.0, 1.0])
         for _ in range(5):
-            _add_complete_trial(
-                study, {0: rank1_vals}, [rank1_vals["loss"], rank1_vals["acc"]]
-            )
+            _add_complete_trial(study, {0: rank1_vals}, [rank1_vals["loss"], rank1_vals["acc"]])
         wrapped = _ask_wrapped(study)
         wrapped.report(current_vals, step=0)
         assert (not wrapped.should_prune()) is expected_not_pruned
@@ -515,9 +513,7 @@ class TestEndToEnd:
             mmt = MultiMetricPrunerTrial(trial)
             x = mmt.suggest_float("x", -5.0, 5.0)
             for step in range(10):
-                mmt.report(
-                    {"loss": (x - step * 0.1) ** 2, "acc": (x + step * 0.1) ** 2}, step
-                )
+                mmt.report({"loss": (x - step * 0.1) ** 2, "acc": (x + step * 0.1) ** 2}, step)
                 if mmt.should_prune():
                     raise optuna.TrialPruned()
             return x**2, (x - 2.0) ** 2
@@ -663,7 +659,10 @@ class TestArgsortByHvContribution:
         ],
     )
     def test_edge_cases(self, loss_vals: list, expected: list) -> None:
-        assert _argsort_by_hv_contribution(np.array(loss_vals), np.array([5.0, 5.0])).tolist() == expected
+        assert (
+            _argsort_by_hv_contribution(np.array(loss_vals), np.array([5.0, 5.0])).tolist()
+            == expected
+        )
 
 
 # ── _tie_break ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Since `MultiMetricPruner` enables us to prune per metric, we should be able to specify different pruners per metric.
This PR adds such feature.

## Description of the changes

<!-- Describe the changes in this PR. -->
- Add per-metric pruner