### PR TITLE
Fix `CatCmawmSampler` crash when search space has no float parameters

### DIFF
--- a/package/samplers/catcmawm/catcmawm.py
+++ b/package/samplers/catcmawm/catcmawm.py
@@ -331,7 +331,7 @@ class CatCmawmSampler(BaseSampler):
         population_size: Optional[int] = None,
     ) -> "CmaClass":
         return cmaes.CatCMAwM(  # type: ignore
-            x_space=x_space=float_bounds if float_bounds else None,
+            x_space=float_bounds if float_bounds else None,
             z_space=int_values,
             c_space=cat_num,
             population_size=population_size,

--- a/package/samplers/catcmawm/catcmawm.py
+++ b/package/samplers/catcmawm/catcmawm.py
@@ -331,7 +331,7 @@ class CatCmawmSampler(BaseSampler):
         population_size: Optional[int] = None,
     ) -> "CmaClass":
         return cmaes.CatCMAwM(  # type: ignore
-            x_space=float_bounds,
+            x_space=x_space=float_bounds if float_bounds else None,
             z_space=int_values,
             c_space=cat_num,
             population_size=population_size,


### PR DESCRIPTION
Motivation:


`CatCmawmSampler` crashes with `ValueError: x_space must be a two-dimensional array`
when the search space has no `FloatDistribution` parameters (only `IntDistribution`
and/or `CategoricalDistribution`). This makes the sampler unusable on purely
discrete/categorical problems, which is a natural use case for CatCMAwM.
Description of the changes:


In `_init_optimizer`, `float_bounds` is an empty list `[]` when there are no float
parameters. This gets passed as `x_space=[]` to `cmaes.CatCMAwM`, which rejects it
because it expects `None` for this case, not an empty list.

Fix: pass `None` instead of `[]` when `float_bounds` is empty.

```python
# before
x_space=float_bounds,

# after
x_space=float_bounds if float_bounds else None,
Minimal reproducer:


import optuna
import optunahub

module = optunahub.load_module("samplers/catcmawm")

def objective(trial):
    x = trial.suggest_int("x", 0, 10)
    y = trial.suggest_categorical("y", [0, 1, 2, 3])
    return x + y

sampler = module.CatCmawmSampler(seed=42)
study = optuna.create_study(sampler=sampler)
study.optimize(objective, n_trials=5)  # completes without error

