### PR TITLE
Ensure no double count in tree plot

### DIFF
--- a/package/visualization/plot_brute_force_tree/_tree.py
+++ b/package/visualization/plot_brute_force_tree/_tree.py
@@ -133,5 +133,6 @@ def build_full_tree(trials: list[FrozenTrial]) -> _TreeNode:
         if (leaf := tree.add_path(_get_trial_path(trial))) is not None:
             leaf.trial_number = trial.number
             if trial.state in [TrialState.COMPLETE, TrialState.PRUNED]:
-                leaf.n_completed += 1
+                # This ensures no double count for any duplicated trials.
+                leaf.n_completed = 1
     return tree


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

<!-- Describe your motivation why you will submit this PR. This is useful for reviewers to understand the context of PR. -->

Currently, the visualization double-counts any duplicated trials.
This PR prevents this.

## Description of the changes

- Exclude double counts