### PR TITLE
Update pre-commit tool versions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,10 +1,6 @@
 name: Checks
 on:
-  push:
-    branches:
-      - main
   pull_request: {}
-  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -15,8 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - uses: pre-commit/action@v3.0.1
-  
+        with:
+          extra_args: >-
+            --from-ref ${{ github.event.pull_request.base.sha }}
+            --to-ref ${{ github.event.pull_request.head.sha }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.15.21
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
@@ -11,14 +11,14 @@ repos:
       - id: ruff-format
         types_or: [python, pyi]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v2.3.0
     hooks:
     - id: mypy
       additional_dependencies: [
         "types-PyYAML",
       ]
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.16
+    rev: 1.0.0
     hooks:
       - id: mdformat
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
     hooks:
       - id: mdformat
         additional_dependencies:
-          - mdformat-frontmatter
           - mdformat-myst
         # Ignore only the `README.md` for this repository and check the others in `packages`.
         exclude: ^(.github/|README.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ checking = [
   "ruff==0.3.5",
   "mdformat",
   "mdformat-myst",
-  "mdformat-frontmatter",
   "mypy==1.9.0",
   "types-PyYAML",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,6 @@ dynamic = ["version"]
 [project.optional-dependencies]
 checking = [
   "pre-commit",
-  "ruff==0.3.5",
-  "mdformat",
-  "mdformat-myst",
-  "mypy==1.9.0",
-  "types-PyYAML",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation & Description of the changes

Addess https://github.com/optuna/optunahub-registry/issues/400.

- Update pre-commit hook versions used in CI
- Limit CI checks to files changed in the PR so unrelated existing files do not fail the workflow
- Remove explicit `mdformat-frontmatter` dependency and rely on `mdformat-myst`'s front matter support

## Details

`mdformat-myst` now brings `mdformat-front-matters`, which also registers a `front_matter` renderer. Keeping `mdformat-frontmatter` installed caused this warning in CI:

```text
Warning: Plugin conflict. More than one plugin defined a renderer for "front_matter" syntax.
```

This PR removes the duplicate front matter plugin while preserving front matter formatting behavior.

## Verification

- Confirmed `mdformat` no longer emits the plugin conflict warning
- Compared front matter output before and after the dependency change
- Confirmed front matter output is unchanged for all tracked Markdown files with front matter