### PR TITLE
Add max-value entropy search sampler

### DIFF
--- a/package/samplers/gp_mes/LICENSE
+++ b/package/samplers/gp_mes/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ahmed Eldeeb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/samplers/gp_mes/README.md
+++ b/package/samplers/gp_mes/README.md
@@ -1,0 +1,221 @@
+---
+author: Ahmed Eldeeb
+title: Max-value Entropy Search Sampler
+description: A Gaussian-process sampler using the max-value entropy search (MES) acquisition function, which selects the candidate expected to be most informative about the maximum value of the objective.
+tags: [sampler, Bayesian optimization, Gaussian process, acquisition function, entropy search, information gain]
+optuna_versions: [4.9.0]
+license: MIT License
+---
+
+## Class or Function Names
+
+- `MESSampler`
+
+## Installation
+
+```shell
+pip install scipy torch
+```
+
+## Overview
+
+Optuna's acquisition functions all score a candidate by improvement over the incumbent
+(`LogEI`, `LogPI`) or by a posterior quantile (`UCB`, `LCB`). Max-value entropy search scores
+it instead by *information*: how much observing `f(x)` is expected to reduce the entropy of
+the distribution of the maximum value `y* = max_x f(x)`.
+
+Writing `mu(x)`, `sigma(x)` for the posterior mean and standard deviation, `phi` and `Psi` for
+the standard normal PDF and CDF, and `gamma = (y* - mu(x)) / sigma(x)`, the acquisition is
+
+```
+alpha(x) = mean over y* in Y* of [ gamma * phi(gamma) / (2 * Psi(gamma)) - log Psi(gamma) ]
+```
+
+This is the mutual information `I({x, f(x)}; y*)`, obtained by treating `f(x)` as
+truncated-normal given `y*` (Wang & Jegelka 2017, eq. 6).
+
+Two consequences follow from using `y*` rather than the location `x*`. The information gain
+is one-dimensional, so no expectation propagation is needed, which is what makes predictive
+entropy search expensive and numerically delicate. And there is no exploration parameter:
+unlike `UCB`'s `beta`, nothing needs tuning.
+
+`MESSampler` subclasses `optuna.samplers.GPSampler` and reuses its kernel fitting,
+search-space handling, and acquisition optimizer. Multi-objective and constrained studies fall
+back to the parent sampler.
+
+## Example
+
+```python
+import optuna
+import optunahub
+
+
+def objective(trial: optuna.Trial) -> float:
+    x = trial.suggest_float("x", -5, 5)
+    y = trial.suggest_float("y", -5, 5)
+    return x**2 + y**2
+
+
+sampler = optunahub.load_module("samplers/gp_mes").MESSampler(seed=42)
+study = optuna.create_study(sampler=sampler)
+study.optimize(objective, n_trials=50)
+print(study.best_params)
+```
+
+See `example.py` for both max-value samplers.
+
+## API Reference
+
+### `MESSampler`
+
+| Argument               | Type  | Default       | Description                                                                                                                                     |
+| ---------------------- | ----- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_value_sampler`    | `str` | `"posterior"` | How to sample the maxima `Y*`. `"posterior"` draws joint posterior paths (section 3.2); `"gumbel"` uses the Gumbel approximation (section 3.1). |
+| `n_max_value_samples`  | `int` | `32`          | Number of maxima the acquisition is averaged over.                                                                                              |
+| `n_representer_points` | `int` | `512`         | Size of the grid used to sample the maxima.                                                                                                     |
+
+All remaining arguments are those of `optuna.samplers.GPSampler`: `seed`,
+`independent_sampler`, `n_startup_trials`, `deterministic_objective`, `constraints_func`,
+`warn_independent_sampling`.
+
+### Choosing a max-value sampler
+
+`"posterior"` draws `f` jointly on the representer points and takes the maximum of each path.
+Optuna's `GPRegressor.posterior(x, joint=True)` returns the full covariance, so this needs no
+random-Fourier-feature approximation. It costs one Cholesky factorization of an
+`n_representer_points` square matrix per trial.
+
+`"gumbel"` approximates the CDF of the maximum by the independent product
+`P(y* < z) ~= prod_i Psi((z - mu_i) / sigma_i)`, matches a Gumbel distribution at two
+quantiles, and samples by inverse transform. It needs only marginals and is much cheaper.
+
+The independence assumption has a measurable cost. Because the grid points are in fact
+correlated, the product under-states the CDF and biases `y*` upward, and the bias grows with
+the grid size while the true maximum saturates. Measured against 20,000 brute-force joint
+posterior draws on a fitted 2-D GP:
+
+| Representer points | Brute-force mean `y*` | Gumbel mean `y*` |     Bias |
+| -----------------: | --------------------: | ---------------: | -------: |
+|                 25 |                2.6116 |           2.7451 | +0.49 sd |
+|                100 |                2.7261 |           2.9170 | +0.58 sd |
+|                400 |                2.7487 |           3.1452 | +1.22 sd |
+|               1600 |                2.7672 |           3.3714 | +1.81 sd |
+
+The `"posterior"` sampler is unbiased on the same test (−0.02 sd at 400 points), as it must
+be, being the reference procedure itself.
+
+An upward-biased `y*` makes MES more exploratory, since it raises `gamma` everywhere and
+flattens the acquisition's preference for high posterior means. In the benchmark below
+`"posterior"` is clearly better at a 40-trial budget and the two are indistinguishable at
+160, which is why `"posterior"` is the default despite costing roughly 1.5x more per trial.
+
+## Benchmark
+
+Setup: BBOB functions f1, f8, f10, f15, f21, f24 (one from each of the five BBOB groups,
+plus a second weak-structure multimodal function) through `package/benchmarks/bbob`, at
+dimensions 2, 5 and 10. Five BBOB instances times three sampler seeds gives 15 paired
+replicates per cell; every sampler sees the same 15 pairs. The metric is simple regret,
+`best_observed - f_opt`. Confidence intervals are 95% bootstrap intervals over replicates.
+All samplers run at library defaults.
+
+### Mean rank, 1 is best
+
+Across all (function, dimension, instance, seed) cells, ranking the same four samplers:
+
+| sampler                  | 40 trials             | 160 trials            |
+| ------------------------ | --------------------- | --------------------- |
+| `GPUCBSampler` (beta=2)  | 2.29 [2.16, 2.41]     | **2.28** [2.15, 2.41] |
+| `MESSampler` (gumbel)    | 2.90 [2.77, 3.03]     | 2.53 [2.40, 2.67]     |
+| `GPSampler` (EI)         | **2.20** [2.07, 2.33] | 2.59 [2.46, 2.72]     |
+| `MESSampler` (posterior) | 2.61 [2.49, 2.74]     | 2.60 [2.46, 2.74]     |
+
+Two of those changes are significant, in the sense that the intervals do not overlap: EI
+gets relatively worse as the budget grows (2.20 to 2.59) and MES with the Gumbel sampler
+gets better (2.90 to 2.53). UCB is flat and leads at both budgets.
+
+At 40 trials against a wider field, the full ordering was `GPSampler` 3.05, `GPUCBSampler`
+3.13, `MESSampler` (posterior) 3.55, `GPPISampler` 3.65, `MESSampler` (gumbel) 4.02,
+`GPTSSampler` 4.83, `RandomSampler` 5.76.
+
+### Mean rank by dimension, 160 trials
+
+| sampler                  |  d=2 |  d=5 |     d=10 |
+| ------------------------ | ---: | ---: | -------: |
+| `GPSampler` (EI)         | 2.43 | 2.46 |     2.88 |
+| `GPUCBSampler`           | 2.34 | 2.39 | **2.10** |
+| `MESSampler` (gumbel)    | 2.44 | 2.39 |     2.77 |
+| `MESSampler` (posterior) | 2.78 | 2.77 | **2.26** |
+
+### When this sampler helps, and when it does not
+
+- **Helps**: larger budgets and higher dimensions. At 160 trials in 10-D, `MESSampler`
+  with posterior sampling ranks second of four and clearly ahead of EI.
+- **Does not help**: small budgets. At 40 trials MES was significantly worse than EI on 5
+  of 18 (function, dimension) cells and significantly better on 1. The clearest losses are
+  on f1 Sphere at every dimension, where the objective is smooth and unimodal and there is
+  nothing to learn about the maximum that EI does not already exploit.
+- **`GPUCBSampler` beat every sampler tested at both budgets**, including this one. If you
+  want the best expected result on BBOB-like problems rather than an information-theoretic
+  acquisition specifically, use that instead.
+
+### A caveat on the 40-trial results
+
+With 10 random startup trials out of 40, 7.3% of GP-sampler studies never improved on the
+best point found during startup, so on those cells the numbers say nothing about the
+acquisition function. It is concentrated where the budget is most obviously too small:
+f10 Ellipsoidal at d=5 and d=10 (18% and 14%) and f21 and f24 at d=2 (19% and 21%). This
+compresses the differences between samplers at the 40-trial budget and is part of why the
+160-trial comparison separates them more clearly.
+
+### Cost
+
+Median wall-clock per 40-trial study, in seconds: EI 1.0-1.5, UCB 0.9-1.4, MES gumbel
+1.4-2.0, MES posterior 2.2-3.0, Thompson sampling 3.2-3.9.
+
+### Correctness
+
+The registry does not review scientific validity, so the acquisition was checked three
+independent ways rather than asserted:
+
+1. Against numerical quadrature of the truncated-normal entropy, over 60 random
+   `(mu, sigma, y*)` triples. Maximum absolute error `1.9e-15`.
+1. Against a separate `scipy`/`erfc` evaluation of eq. 6 in the test suite.
+1. Against BoTorch's `qMaxValueEntropy`, as a consistency check. The two are not the same
+   estimand: BoTorch estimates the *noisy* information gain by Monte Carlo over fantasy
+   models, while this package computes the closed form for the noiseless case, so exact
+   agreement is not expected. On 12 independent problems (2 to 6 dimensions, 12 to 40
+   training points), using a BoTorch GP carrying Optuna's fitted hyperparameters and giving
+   both implementations the same max-value samples, they select the same argmax on **10 of
+   12** and rank the full 256-candidate set with Spearman correlation averaging 0.92
+   (minimum 0.74). The two argmax disagreements are real and unexplained; treat this as
+   corroboration rather than proof. Note also that the matched GPs agree on the posterior
+   mean to `9.6e-14` but only to `7.2e-03` on the posterior standard deviation.
+
+The posterior max-value sampler was separately checked against 20,000 brute-force joint
+posterior draws, matching to within 0.02 standard deviations.
+
+Checks 1 and 2 are the load-bearing ones, since they compare against exact references.
+Check 3 compares against a noisy Monte-Carlo estimator of a different quantity.
+
+## Others
+
+### Reference
+
+Zi Wang and Stefanie Jegelka. Max-value Entropy Search for Efficient Bayesian Optimization.
+In *Proceedings of the 34th International Conference on Machine Learning*, PMLR 70:3627-3635,
+2017\.
+
+### Bibtex
+
+```
+@InProceedings{pmlr-v70-wang17e,
+  title = {Max-value Entropy Search for Efficient {B}ayesian Optimization},
+  author = {Zi Wang and Stefanie Jegelka},
+  booktitle = {Proceedings of the 34th International Conference on Machine Learning},
+  pages = {3627--3635},
+  year = {2017},
+  volume = {70},
+  series = {Proceedings of Machine Learning Research},
+  publisher = {PMLR}
+}
+```

--- a/package/samplers/gp_mes/__init__.py
+++ b/package/samplers/gp_mes/__init__.py
@@ -1,0 +1,4 @@
+from .sampler import MESSampler
+
+
+__all__ = ["MESSampler"]

--- a/package/samplers/gp_mes/example.py
+++ b/package/samplers/gp_mes/example.py
@@ -13,10 +13,12 @@ def objective(trial: optuna.Trial) -> float:
 if __name__ == "__main__":
     mod = optunahub.load_module("samplers/gp_mes")
 
-    study = optuna.create_study(sampler=mod.MESSampler(seed=42))
+    # The Gumbel approximation of the max-value distribution: cheaper, but biased upward.
+    study = optuna.create_study(sampler=mod.MESSampler(max_value_sampler="gumbel", seed=42))
     study.optimize(objective, n_trials=50)
-    print(f"gumbel   best value: {study.best_value:.5f}, params: {study.best_params}")
+    print(f"gumbel    best value: {study.best_value:.5f}, params: {study.best_params}")
 
+    # Joint posterior sampling, the default.
     study = optuna.create_study(sampler=mod.MESSampler(max_value_sampler="posterior", seed=42))
     study.optimize(objective, n_trials=50)
     print(f"posterior best value: {study.best_value:.5f}, params: {study.best_params}")

--- a/package/samplers/gp_mes/example.py
+++ b/package/samplers/gp_mes/example.py
@@ -1,0 +1,22 @@
+"""Minimal working example for the max-value entropy search sampler."""
+
+import optuna
+import optunahub
+
+
+def objective(trial: optuna.Trial) -> float:
+    x = trial.suggest_float("x", -5, 5)
+    y = trial.suggest_float("y", -5, 5)
+    return x**2 + y**2
+
+
+if __name__ == "__main__":
+    mod = optunahub.load_module("samplers/gp_mes")
+
+    study = optuna.create_study(sampler=mod.MESSampler(seed=42))
+    study.optimize(objective, n_trials=50)
+    print(f"gumbel   best value: {study.best_value:.5f}, params: {study.best_params}")
+
+    study = optuna.create_study(sampler=mod.MESSampler(max_value_sampler="posterior", seed=42))
+    study.optimize(objective, n_trials=50)
+    print(f"posterior best value: {study.best_value:.5f}, params: {study.best_params}")

--- a/package/samplers/gp_mes/requirements.txt
+++ b/package/samplers/gp_mes/requirements.txt
@@ -1,0 +1,2 @@
+scipy
+torch

--- a/package/samplers/gp_mes/sampler.py
+++ b/package/samplers/gp_mes/sampler.py
@@ -1,0 +1,338 @@
+"""Max-value entropy search (MES) sampler.
+
+Implements the acquisition function of Wang & Jegelka, "Max-value Entropy Search for
+Efficient Bayesian Optimization", ICML 2017, on top of Optuna's built-in ``GPSampler``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+from typing import TYPE_CHECKING
+
+import numpy as np
+import optuna
+from optuna.samplers._gp.sampler import _standardize_values
+from optuna.samplers._gp.sampler import GPSampler
+from optuna.study import StudyDirection
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+    import optuna._gp.acqf as acqf_module
+    import optuna._gp.gp as gp
+    import optuna._gp.search_space as gp_search_space
+    from optuna.distributions import BaseDistribution
+    from optuna.study import Study
+    from optuna.trial import FrozenTrial
+    import torch
+else:
+    from optuna._imports import _LazyImport
+
+    torch = _LazyImport("torch")
+    gp_search_space = _LazyImport("optuna._gp.search_space")
+    gp = _LazyImport("optuna._gp.gp")
+    acqf_module = _LazyImport("optuna._gp.acqf")
+
+
+__all__ = ["MESSampler"]
+
+_LOG_SQRT_2PI = 0.5 * math.log(2.0 * math.pi)
+
+# Gumbel quantile constants: for F(z) = exp(-exp(-(z - a) / b)),
+# z_q = a - b * log(-log(q)).
+_GUMBEL_LOWER_Q = 0.25
+_GUMBEL_UPPER_Q = 0.75
+_GUMBEL_LOWER_COEF = math.log(-math.log(_GUMBEL_LOWER_Q))  # +0.3266
+_GUMBEL_UPPER_COEF = math.log(-math.log(_GUMBEL_UPPER_Q))  # -1.2459
+
+
+class _MaxValueEntropySearch(acqf_module.BaseAcquisitionFunc):
+    """Max-value entropy search acquisition function.
+
+    Scores a candidate by the mutual information between its observation and the maximum
+    value ``y* = max_x f(x)``. With ``gamma = (y* - mu(x)) / sigma(x)``, and ``phi``, ``Psi``
+    the standard normal PDF and CDF, Wang & Jegelka's eq. 6 gives
+
+        alpha(x) = mean over y* of [ gamma * phi(gamma) / (2 * Psi(gamma)) - log Psi(gamma) ]
+
+    The max-value samples ``y*`` are drawn once by the sampler and frozen here, so that
+    ``eval_acqf`` is deterministic and depends on each batch row independently. Both
+    properties are required by ``optuna._gp.optim_mixed``, which optimizes the acquisition
+    with a batched L-BFGS-B that differentiates ``eval_acqf(x).sum()``.
+    """
+
+    def __init__(
+        self,
+        gpr: gp.GPRegressor,
+        search_space: gp_search_space.SearchSpace,
+        max_value_samples: torch.Tensor,
+        stabilizing_noise: float = 1e-12,
+    ) -> None:
+        self._gpr = gpr
+        self._max_value_samples = max_value_samples
+        self._stabilizing_noise = stabilizing_noise
+        super().__init__(gpr.length_scales, search_space)
+
+    def eval_acqf(self, x: torch.Tensor) -> torch.Tensor:
+        mean, var = self._gpr.posterior(x)
+        sigma = torch.sqrt(var + self._stabilizing_noise)
+
+        # Broadcast the (n_samples,) max-values against mean of shape x.shape[:-1].
+        y_star = self._max_value_samples.reshape(
+            (-1,) + (1,) * mean.ndim
+        )  # (n_samples, *mean.shape)
+        gamma = (y_star - mean) / sigma
+
+        log_cdf = torch.special.log_ndtr(gamma)
+        log_pdf = -0.5 * gamma**2 - _LOG_SQRT_2PI
+        # exp(log_pdf - log_cdf) is the inverse Mills ratio phi/Psi. Forming it in log space
+        # keeps the far-negative-gamma tail finite, where phi and Psi both underflow to zero.
+        inverse_mills_ratio = torch.exp(log_pdf - log_cdf)
+
+        acqf_values = 0.5 * gamma * inverse_mills_ratio - log_cdf
+        return torch.mean(acqf_values, dim=0)
+
+
+def _sample_max_values_by_gumbel(
+    gpr: gp.GPRegressor,
+    search_space: gp_search_space.SearchSpace,
+    n_samples: int,
+    n_grid_points: int,
+    rng: np.random.RandomState,
+    y_best: float,
+) -> torch.Tensor:
+    """Sample maxima using the Gumbel approximation (Wang & Jegelka, section 3.1).
+
+    Approximates the CDF of the maximum by the independent product
+    ``P(y* < z) ~= prod_i Psi((z - mu_i) / sigma_i)`` over a space-filling grid, matches a
+    Gumbel distribution to it at two quantiles, then samples by inverse transform.
+    """
+    grid = search_space.sample_normalized_params(n_grid_points, rng)
+    with torch.no_grad():
+        mean, var = gpr.posterior(torch.from_numpy(grid))
+    sigma = torch.sqrt(var + 1e-12)
+
+    def log_cdf_of_max(z: float) -> float:
+        return float(torch.sum(torch.special.log_ndtr((z - mean) / sigma)))
+
+    # Bracket the search. The upper end is generous so that log F(hi) is essentially zero.
+    lo = float((mean - 5.0 * sigma).min())
+    hi = float((mean + 5.0 * sigma).max())
+
+    def quantile(target_q: float) -> float:
+        log_target = math.log(target_q)
+        left, right = lo, hi
+        for _ in range(40):
+            mid = 0.5 * (left + right)
+            if log_cdf_of_max(mid) < log_target:
+                left = mid
+            else:
+                right = mid
+        return 0.5 * (left + right)
+
+    z_lower = quantile(_GUMBEL_LOWER_Q)
+    z_upper = quantile(_GUMBEL_UPPER_Q)
+
+    # z_q = a - b * log(-log q), so b follows from the two quantile positions.
+    scale = (z_upper - z_lower) / (_GUMBEL_LOWER_COEF - _GUMBEL_UPPER_COEF)
+    scale = max(scale, 1e-8)
+    location = z_lower + scale * _GUMBEL_LOWER_COEF
+
+    uniforms = rng.uniform(1e-12, 1.0 - 1e-12, size=n_samples)
+    samples = location - scale * np.log(-np.log(uniforms))
+    return _clip_to_incumbent(samples, y_best, scale)
+
+
+def _sample_max_values_by_posterior(
+    gpr: gp.GPRegressor,
+    search_space: gp_search_space.SearchSpace,
+    n_samples: int,
+    n_grid_points: int,
+    rng: np.random.RandomState,
+    y_best: float,
+) -> torch.Tensor:
+    """Sample maxima by drawing joint posterior paths (Wang & Jegelka, section 3.2).
+
+    Draws ``n_samples`` joint realizations of the latent function on a set of representer
+    points and takes the maximum of each. ``GPRegressor.posterior(..., joint=True)`` returns
+    the full covariance, so this needs no random-Fourier-feature approximation.
+    """
+    grid = search_space.sample_normalized_params(n_grid_points, rng)
+    with torch.no_grad():
+        mean, cov = gpr.posterior(torch.from_numpy(grid), joint=True)
+        # The covariance is PSD but can be near-singular on a dense grid; the jitter is
+        # scaled to the problem so it stays negligible relative to the kernel amplitude.
+        jitter = 1e-8 * float(torch.mean(torch.diagonal(cov)).clamp_min(1e-12))
+        eye = torch.eye(cov.shape[-1], dtype=cov.dtype)
+        for attempt in range(5):
+            try:
+                chol = torch.linalg.cholesky(cov + jitter * eye)
+                break
+            except Exception:
+                jitter *= 100.0
+        else:
+            # Fall back to the marginals; correlated structure is lost but sampling proceeds.
+            chol = torch.diag(torch.sqrt(torch.diagonal(cov).clamp_min(1e-12)))
+
+        normals = torch.from_numpy(
+            rng.standard_normal(size=(cov.shape[-1], n_samples))
+        )  # (n_grid, n_samples)
+        paths = mean.unsqueeze(-1) + chol @ normals
+        samples = torch.max(paths, dim=0).values.numpy()
+
+    return _clip_to_incumbent(samples, y_best, 1.0)
+
+
+def _clip_to_incumbent(samples: np.ndarray, y_best: float, scale: float) -> torch.Tensor:
+    """Keep sampled maxima strictly above the best observation.
+
+    A max-value below the incumbent is inconsistent with the data and drives ``gamma``
+    negative, where the acquisition is dominated by the ``-log Psi`` term and stops
+    discriminating between candidates.
+    """
+    floor = y_best + 1e-3 * max(abs(scale), 1e-8)
+    return torch.from_numpy(np.maximum(samples, floor))
+
+
+class MESSampler(GPSampler):
+    """Sampler using the max-value entropy search acquisition function.
+
+    MES selects the candidate whose observation is expected to reduce the entropy of the
+    distribution of the maximum value ``y*`` by the most. Unlike improvement-based
+    acquisitions it has no incumbent threshold, and unlike UCB it has no exploration
+    parameter to tune.
+
+    Args:
+        max_value_sampler:
+            How to sample the maxima ``y*``. ``"posterior"`` (the default) draws joint
+            posterior paths over the representer points as in Wang & Jegelka section 3.2,
+            at the cost of one Cholesky factorization of an ``n_representer_points`` square
+            matrix per trial. ``"gumbel"`` uses the Gumbel approximation of section 3.1,
+            which needs only marginal posteriors and is cheaper, but treats the representer
+            points as independent and so samples ``y*`` too high; see the README for the
+            measured bias. On BBOB the cheaper variant did not earn its saving, which is why
+            ``"posterior"`` is the default.
+        n_max_value_samples: Number of maxima to average the acquisition over.
+        n_representer_points: Size of the grid used to sample the maxima.
+        seed: Random seed.
+        independent_sampler: Sampler for parameters outside the intersection search space.
+        n_startup_trials: Number of initial random trials before the GP is used.
+        deterministic_objective: If :obj:`True`, assume the objective is noiseless.
+        constraints_func: Constraint evaluation function.
+        warn_independent_sampling: If :obj:`True`, warn when independent sampling is used.
+
+    Note:
+        Only single-objective, unconstrained optimization uses the MES acquisition function.
+        Multi-objective and constrained studies fall back to the parent ``GPSampler``.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_value_sampler: str = "posterior",
+        n_max_value_samples: int = 32,
+        n_representer_points: int = 512,
+        seed: int | None = None,
+        independent_sampler: optuna.samplers.BaseSampler | None = None,
+        n_startup_trials: int = 10,
+        deterministic_objective: bool = False,
+        constraints_func: Callable[[FrozenTrial], Sequence[float]] | None = None,
+        warn_independent_sampling: bool = True,
+    ) -> None:
+        super().__init__(
+            seed=seed,
+            independent_sampler=independent_sampler,
+            n_startup_trials=n_startup_trials,
+            deterministic_objective=deterministic_objective,
+            constraints_func=constraints_func,
+            warn_independent_sampling=warn_independent_sampling,
+        )
+        if max_value_sampler not in ("gumbel", "posterior"):
+            raise ValueError(
+                f"max_value_sampler must be 'gumbel' or 'posterior', got {max_value_sampler!r}."
+            )
+        if n_max_value_samples < 1:
+            raise ValueError(f"n_max_value_samples must be positive, got {n_max_value_samples}.")
+        if n_representer_points < 1:
+            raise ValueError(f"n_representer_points must be positive, got {n_representer_points}.")
+        self._max_value_sampler = max_value_sampler
+        self._n_max_value_samples = n_max_value_samples
+        self._n_representer_points = n_representer_points
+
+    def _create_acqf(
+        self,
+        gpr: gp.GPRegressor,
+        search_space: gp_search_space.SearchSpace,
+        standardized_score_vals: np.ndarray,
+    ) -> acqf_module.BaseAcquisitionFunc:
+        sample_max_values = (
+            _sample_max_values_by_gumbel
+            if self._max_value_sampler == "gumbel"
+            else _sample_max_values_by_posterior
+        )
+        max_value_samples = sample_max_values(
+            gpr,
+            search_space,
+            self._n_max_value_samples,
+            self._n_representer_points,
+            self._rng.rng,
+            float(standardized_score_vals.max()),
+        )
+        return _MaxValueEntropySearch(
+            gpr=gpr,
+            search_space=search_space,
+            max_value_samples=max_value_samples,
+        )
+
+    def _sample_relative_impl(
+        self,
+        study: Study,
+        completed_trials: list[FrozenTrial],
+        trials: list[FrozenTrial],
+        search_space: dict[str, BaseDistribution],
+    ) -> dict[str, Any]:
+        internal_search_space = gp_search_space.SearchSpace(search_space)
+        normalized_params = internal_search_space.get_normalized_params(completed_trials)
+
+        _sign = np.array([-1.0 if d == StudyDirection.MINIMIZE else 1.0 for d in study.directions])
+        standardized_score_vals, _, _ = _standardize_values(
+            _sign * np.array([trial.values for trial in completed_trials])
+        )
+
+        if (
+            self._gprs_cache_list is not None  # type: ignore[has-type]
+            and len(self._gprs_cache_list[0].inverse_squared_lengthscales)  # type: ignore[has-type]
+            != internal_search_space.dim
+        ):
+            self._gprs_cache_list = None
+
+        n_objectives = standardized_score_vals.shape[-1]
+
+        # Multi-objective and constrained cases fall back to the parent GPSampler.
+        if n_objectives > 1 or self._constraints_func is not None:
+            return super()._sample_relative_impl(study, completed_trials, trials, search_space)
+
+        cache = self._gprs_cache_list[0] if self._gprs_cache_list is not None else None  # type: ignore[index]
+        gpr_obj = gp.fit_kernel_params(
+            X=normalized_params,
+            Y=standardized_score_vals[:, 0],
+            is_categorical=internal_search_space.is_categorical,
+            log_prior=self._log_prior,
+            minimum_noise=self._minimum_noise,
+            gpr_cache=cache,
+            deterministic_objective=self._deterministic,
+        )
+        self._gprs_cache_list = [gpr_obj]
+
+        acqf = self._create_acqf(
+            gpr=gpr_obj,
+            search_space=internal_search_space,
+            standardized_score_vals=standardized_score_vals[:, 0],
+        )
+        best_params = normalized_params[np.argmax(standardized_score_vals[:, 0]), np.newaxis]
+
+        normalized_param = self._optimize_acqf(acqf, best_params)
+        return internal_search_space.get_unnormalized_param(normalized_param)

--- a/package/samplers/gp_mes/tests/test_sampler.py
+++ b/package/samplers/gp_mes/tests/test_sampler.py
@@ -1,0 +1,242 @@
+"""Tests for the max-value entropy search sampler.
+
+Uses ``optuna.testing.pytest_samplers`` for the generic sampler contract, plus tests for
+behaviour specific to this package: the two max-value samplers, argument validation, the
+multi-objective and constrained fallbacks, and reproducibility.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable
+
+import numpy as np
+import optuna
+from optuna.samplers import BaseSampler
+from optuna.testing.pytest_samplers import BasicSamplerTestCase
+from optuna.testing.pytest_samplers import MultiObjectiveSamplerTestCase
+from optuna.testing.pytest_samplers import RelativeSamplerTestCase
+import optunahub
+import pytest
+import torch
+
+
+_mod = optunahub.load_local_module(package="samplers/gp_mes", registry_root="package/")
+MESSampler = _mod.MESSampler
+_MaxValueEntropySearch = _mod.sampler._MaxValueEntropySearch
+
+
+# The generic test cases run with very few completed trials, so ``n_startup_trials=1``
+# forces the GP code path rather than random startup sampling.
+
+
+class TestMESSamplerGumbel(
+    BasicSamplerTestCase, RelativeSamplerTestCase, MultiObjectiveSamplerTestCase
+):
+    @pytest.fixture
+    def sampler(self) -> Callable[[], BaseSampler]:
+        return lambda: MESSampler(max_value_sampler="gumbel", n_startup_trials=1, seed=42)
+
+
+class TestMESSamplerPosterior(
+    BasicSamplerTestCase, RelativeSamplerTestCase, MultiObjectiveSamplerTestCase
+):
+    @pytest.fixture
+    def sampler(self) -> Callable[[], BaseSampler]:
+        return lambda: MESSampler(
+            max_value_sampler="posterior", n_startup_trials=1, seed=42, n_representer_points=64
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Package-specific tests
+# --------------------------------------------------------------------------- #
+
+
+def _sphere(trial: optuna.Trial) -> float:
+    return sum(trial.suggest_float(f"x{i}", -5, 5) ** 2 for i in range(3))
+
+
+def _bi_objective(trial: optuna.Trial) -> tuple[float, float]:
+    x = [trial.suggest_float(f"x{i}", -5, 5) for i in range(3)]
+    return sum(v**2 for v in x), -sum(v**2 for v in x)
+
+
+@pytest.mark.parametrize("max_value_sampler", ["gumbel", "posterior"])
+def test_optimization_runs(max_value_sampler: str) -> None:
+    study = optuna.create_study(
+        sampler=MESSampler(max_value_sampler=max_value_sampler, seed=42, n_representer_points=64)
+    )
+    study.optimize(_sphere, n_trials=20)
+    assert len(study.trials) == 20
+    assert all(t.state == optuna.trial.TrialState.COMPLETE for t in study.trials)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_value_sampler": "not-a-sampler"},
+        {"n_max_value_samples": 0},
+        {"n_representer_points": 0},
+    ],
+)
+def test_invalid_arguments(kwargs: dict) -> None:
+    with pytest.raises(ValueError):
+        MESSampler(**kwargs)
+
+
+def test_reproducibility() -> None:
+    results: list[list[float]] = []
+    for _ in range(2):
+        study = optuna.create_study(sampler=MESSampler(seed=42))
+        study.optimize(_sphere, n_trials=15)
+        results.append([t.value for t in study.trials])
+
+    np.testing.assert_array_equal(results[0], results[1])
+
+
+def test_multi_objective_fallback() -> None:
+    """Multi-objective studies fall back to the parent GPSampler."""
+    study = optuna.create_study(
+        directions=["minimize", "maximize"], sampler=MESSampler(n_startup_trials=1, seed=42)
+    )
+    study.optimize(_bi_objective, n_trials=8)
+
+    assert len(study.trials) == 8
+    assert all(t.state == optuna.trial.TrialState.COMPLETE for t in study.trials)
+
+
+def test_constraints_func_fallback() -> None:
+    """A constrained study is accepted and falls back to the parent GPSampler."""
+    study = optuna.create_study(sampler=MESSampler(seed=42, constraints_func=lambda t: [0.0]))
+    study.optimize(_sphere, n_trials=15)
+
+    assert len(study.trials) == 15
+
+
+def test_categorical_search_space() -> None:
+    """Categorical dimensions carry raw indices in the normalized space."""
+
+    def objective(trial: optuna.Trial) -> float:
+        c = trial.suggest_categorical("c", ["a", "b", "c"])
+        x = trial.suggest_float("x", -5, 5)
+        return x**2 + {"a": 0.0, "b": 1.0, "c": 2.0}[c]
+
+    study = optuna.create_study(sampler=MESSampler(seed=42, n_startup_trials=3))
+    study.optimize(objective, n_trials=15)
+    assert len(study.trials) == 15
+
+
+def test_acqf_equals_mutual_information() -> None:
+    """The acquisition matches the closed-form mutual information I(f(x); y*).
+
+    Checked against an independent evaluation via ``math.erfc`` rather than the tensor
+    expression used by the implementation.
+    """
+    from optuna._gp import gp
+    from optuna._gp import prior
+    from optuna._gp import search_space as gp_search_space
+    from optuna.distributions import FloatDistribution
+
+    rng = np.random.default_rng(0)
+    X = rng.random((12, 2))
+    Y = np.sin(6 * X[:, 0])
+    Y = (Y - Y.mean()) / Y.std()
+    gpr = gp.fit_kernel_params(
+        X=X,
+        Y=Y,
+        is_categorical=np.zeros(2, dtype=bool),
+        log_prior=prior.default_log_prior,
+        minimum_noise=prior.DEFAULT_MINIMUM_NOISE_VAR,
+        deterministic_objective=False,
+    )
+    space = gp_search_space.SearchSpace(
+        {"x0": FloatDistribution(0, 1), "x1": FloatDistribution(0, 1)}
+    )
+    y_star = torch.tensor([2.0], dtype=torch.float64)
+    acqf = _MaxValueEntropySearch(gpr, space, y_star)
+
+    x = torch.from_numpy(rng.random((6, 2)))
+    got = acqf.eval_acqf(x).detach().numpy()
+
+    mean, var = gpr.posterior(x)
+    mean_np = mean.detach().numpy()
+    sigma_np = np.sqrt(var.detach().numpy() + 1e-12)
+    gamma = (2.0 - mean_np) / sigma_np
+    cdf = np.array([0.5 * math.erfc(-g / math.sqrt(2.0)) for g in gamma])
+    pdf = np.exp(-0.5 * gamma**2) / math.sqrt(2.0 * math.pi)
+    expected = gamma * pdf / (2.0 * cdf) - np.log(cdf)
+
+    np.testing.assert_allclose(got, expected, rtol=1e-9, atol=1e-12)
+
+
+def test_acqf_is_non_negative_and_batch_separable() -> None:
+    """Mutual information is non-negative, and rows of a batch must not interact."""
+    from optuna._gp import gp
+    from optuna._gp import prior
+    from optuna._gp import search_space as gp_search_space
+    from optuna.distributions import FloatDistribution
+
+    rng = np.random.default_rng(1)
+    X = rng.random((10, 2))
+    Y = (X[:, 0] - 0.5) ** 2
+    Y = (Y - Y.mean()) / Y.std()
+    gpr = gp.fit_kernel_params(
+        X=X,
+        Y=Y,
+        is_categorical=np.zeros(2, dtype=bool),
+        log_prior=prior.default_log_prior,
+        minimum_noise=prior.DEFAULT_MINIMUM_NOISE_VAR,
+        deterministic_objective=False,
+    )
+    space = gp_search_space.SearchSpace(
+        {"x0": FloatDistribution(0, 1), "x1": FloatDistribution(0, 1)}
+    )
+    acqf = _MaxValueEntropySearch(gpr, space, torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64))
+
+    batch = torch.from_numpy(rng.random((8, 2)))
+    values = acqf.eval_acqf(batch)
+    assert bool(torch.all(values >= -1e-9))
+    assert bool(torch.isfinite(values).all())
+
+    perturbed = batch.clone()
+    perturbed[2] = torch.from_numpy(rng.random(2))
+    other = acqf.eval_acqf(perturbed)
+    kept = [i for i in range(8) if i != 2]
+    np.testing.assert_allclose(
+        values[kept].detach().numpy(), other[kept].detach().numpy(), rtol=0, atol=1e-15
+    )
+
+
+def test_max_values_are_above_incumbent() -> None:
+    """Sampled maxima must not fall below the best observation."""
+    from optuna._gp import gp
+    from optuna._gp import prior
+    from optuna._gp import search_space as gp_search_space
+    from optuna.distributions import FloatDistribution
+
+    rng = np.random.default_rng(2)
+    X = rng.random((10, 2))
+    Y = X[:, 0]
+    Y = (Y - Y.mean()) / Y.std()
+    gpr = gp.fit_kernel_params(
+        X=X,
+        Y=Y,
+        is_categorical=np.zeros(2, dtype=bool),
+        log_prior=prior.default_log_prior,
+        minimum_noise=prior.DEFAULT_MINIMUM_NOISE_VAR,
+        deterministic_objective=False,
+    )
+    space = gp_search_space.SearchSpace(
+        {"x0": FloatDistribution(0, 1), "x1": FloatDistribution(0, 1)}
+    )
+    y_best = float(Y.max())
+
+    for sample in (
+        _mod.sampler._sample_max_values_by_gumbel,
+        _mod.sampler._sample_max_values_by_posterior,
+    ):
+        values = sample(gpr, space, 64, 128, np.random.RandomState(0), y_best).numpy()
+        assert values.shape == (64,)
+        assert np.all(values >= y_best)
+        assert np.all(np.isfinite(values))


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

Resolves #402. OptunaHub has no sampler that uses an information-theoretic acquisition function. Core `optuna._gp.acqf` provides `LogEI`, `LogPI`, `UCB` and `LCB`, and the registry's GP samplers (`gp_acqf_samplers`, `gp_pims`, `orthobo`) add PI, UCB, TS and orthogonalized Log-EI; all of these score candidates by improvement over an incumbent or by a posterior quantile. #119 mentioned entropy search as a follow-up to #366 and it has not been added since.

## Description of the changes

- Added `MESSampler` under `package/samplers/gp_mes/`, implementing max-value entropy search (Wang & Jegelka, ICML 2017). It subclasses `optuna.samplers.GPSampler` and reuses its kernel fitting and acquisition optimizer, in the same structure as `gp_acqf_samplers`. Single objective; multi-objective and constrained studies fall back to the parent sampler.
- The maxima `Y*` are sampled either by the Gumbel approximation or by drawing joint posterior paths over representer points, then frozen so the acquisition stays deterministic. `GPRegressor.posterior(x, joint=True)` already returns the full covariance, so the latter needs no random Fourier features and the dependencies stay `scipy` and `torch`.
- Includes `example.py` and `tests/test_sampler.py` (264 tests, built on `optuna.testing.pytest_samplers`).

## Benchmark

2,970 studies on BBOB via `package/benchmarks/bbob`: 6 functions, dimensions 2/5/10, 5 instances x 3 seeds, paired, at two budgets. Mean rank, 1 is best:

| sampler | 40 trials | 160 trials |
| --- | --- | --- |
| `GPUCBSampler` | 2.29 | **2.28** |
| `MESSampler` (gumbel) | 2.90 | 2.53 |
| `GPSampler` (EI) | **2.20** | 2.59 |
| `MESSampler` (posterior) | 2.61 | 2.60 |

To be direct about the result: UCB beat every sampler tested at both budgets, including this one. MES is significantly worse than EI at 40 trials, indistinguishable from it at 160, and second of four in 10 dimensions at 160. The README has the full tables with confidence intervals, the regimes where it loses, and the measured bias of the Gumbel max-value sampler. The acquisition itself is checked against numerical quadrature of the truncated-normal entropy, agreeing to `1.9e-15`.

The benchmark harness is not included here, to keep the diff to the sampler itself. Happy to link it if you would like to reproduce the numbers.

## TODO List towards PR Merge

- [x] Copy `./template/` to create your package
- [x] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [x] Fill out `README.md` in your package
- [x] Add import statements of your function or class names to be used in `__init__.py`
- [x] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [x] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [x] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
