### PR TITLE
[samplers/vizier] Cap jax to 0.4.34 to fix jax.core.Primitive break (…

### DIFF
--- a/package/samplers/vizier/README.md
+++ b/package/samplers/vizier/README.md
@@ -18,14 +18,10 @@ It is a simple wrapper around Vizier's Python client, enabling its optimization 
 
 ## Installation
 
-```bash
-pip install google-vizier[jax] # with JAX
-```
-
-or
+This package currently supports Python 3.10–3.13.
 
 ```bash
-pip install google-vizier[all] # with All algorithm
+pip install -r https://hub.optuna.org/samplers/vizier/requirements.txt
 ```
 
 ## Example

--- a/package/samplers/vizier/requirements.txt
+++ b/package/samplers/vizier/requirements.txt
@@ -1,0 +1,3 @@
+﻿google-vizier[jax]
+jax==0.4.34
+jaxlib==0.4.34

--- a/package/samplers/vizier/requirements.txt
+++ b/package/samplers/vizier/requirements.txt
@@ -1,3 +1,3 @@
-﻿google-vizier[jax]
+google-vizier[jax]==0.1.24
 jax==0.4.34
 jaxlib==0.4.34


### PR DESCRIPTION
Fixes #325.

## Problem

The `samplers/vizier` package has no `requirements.txt`, so following the
README's `pip install google-vizier[jax]` lets the resolver choose an
incompatible dependency stack. Running the sampler then crashes on import:

    AttributeError: module 'jax.core' has no attribute 'Primitive'

I reproduced this on a clean install (Windows, Python 3.14 and 3.12): a fresh
`pip install google-vizier[jax]` pulls `google-vizier 0.1.24`, `equinox 0.11.7`,
and `jax 0.11.0`, and importing equinox fails at
`equinox/debug/_announce_transform.py:127`, which calls `jax.core.Primitive(...)`.

## Root cause

`google-vizier==0.1.24` (its latest release) hard-pins `equinox==0.11.7` but
leaves JAX unbounded (`jax>=0.4.34`, no upper bound). equinox 0.11.7 imports
`jax.core.Primitive`, which JAX removed at 0.4.35. With no upper bound on JAX,
pip pairs the pinned old equinox with a modern JAX and the import breaks.

I checked the obvious alternative of pushing equinox *up* instead, and it isn't
viable: requiring a newer equinox forces google-vizier to backtrack to `0.1.16`,
whose client API differs from what this package's `sampler.py` calls
(`study_client.add_trial`), producing a different failure during `after_trial`.

So the correct fix keeps google-vizier at 0.1.24 and caps JAX to the last
version that equinox 0.11.7 supports.

## Change

Adds `package/samplers/vizier/requirements.txt`:

    google-vizier[jax]
    jax==0.4.34
    jaxlib==0.4.34

(`0.4.34` is the only JAX that satisfies both google-vizier's `>=0.4.34`
requirement and the `<0.4.35` ceiling that keeps `jax.core.Primitive` available.)

## Verification

Tested in a fresh virtual environment on Python 3.12:

- `pip install -r package/samplers/vizier/requirements.txt optuna optunahub`
  resolves to google-vizier 0.1.24, equinox 0.11.7, jax 0.4.34, jaxlib 0.4.34
- `pip check` → `No broken requirements found`
- the sampler runs end to end via `optunahub.load_module("samplers/vizier")`:

```python
  import optuna, optunahub
  v = optunahub.load_module("samplers/vizier")
  s = optuna.create_study(sampler=v.VizierSampler(), direction="minimize")
  s.optimize(lambda t: t.suggest_float("x", -10, 10) ** 2
                       + t.suggest_int("y", -10, 10) ** 2, n_trials=6)
  print(s.best_value)
```

  This completes and prints a best value, with no `jax.core.Primitive` error.

`pre-commit run` was run against the changed file (ruff / mypy / mdformat all
skip a plain `requirements.txt`).

## Note on Python support

jax/jaxlib 0.4.34 provide wheels for cp310–cp313 only, so this pins the sampler
to Python <= 3.13; it will not install on Python 3.14. This is a consequence of
google-vizier's stale `equinox==0.11.7` pin, not of this change. The proper
long-term fix is upstream in google-vizier (relaxing the equinox pin so it works
with a JAX that has 3.14 wheels). This PR unblocks the sampler on supported
Python versions in the meantime.