### PR TITLE
Fix DESampler generation-retrieval scaling with total trial count (#405)

### DIFF
--- a/package/samplers/differential_evolution/README.md
+++ b/package/samplers/differential_evolution/README.md
@@ -115,6 +115,21 @@ Seed for the random number generator, ensuring reproducibility of results.
 
 - **Default**: `None`
 - **Example**: `seed=42`
+______________________________________________________________________
+
+## Generation Semantics
+
+`DESampler` groups trials into generations by study-local trial creation order:
+
+```python
+generation = trial.number // population_size
+```
+
+Two consequences of this definition are worth noting:
+
+- **Generation boundaries are not completion barriers.** Under asynchronous execution (`n_jobs > 1`), trials in generation `g + 1` may be sampled before every trial in generation `g` has completed. A generation is therefore not guaranteed to be sampled from the fully updated population of the previous generation.
+- **Failed or pruned trials still consume their trial-number slot.** A generation may contain fewer than `population_size` completed trials. When the previous generation does not have exactly `population_size` completed trials, the DE update for that step is skipped and sampling falls back accordingly.
+
 
 ## Installation
 

--- a/package/samplers/differential_evolution/README.md
+++ b/package/samplers/differential_evolution/README.md
@@ -115,6 +115,7 @@ Seed for the random number generator, ensuring reproducibility of results.
 
 - **Default**: `None`
 - **Example**: `seed=42`
+
 ______________________________________________________________________
 
 ## Generation Semantics
@@ -129,7 +130,6 @@ Two consequences of this definition are worth noting:
 
 - **Generation boundaries are not completion barriers.** Under asynchronous execution (`n_jobs > 1`), trials in generation `g + 1` may be sampled before every trial in generation `g` has completed. A generation is therefore not guaranteed to be sampled from the fully updated population of the previous generation.
 - **Failed or pruned trials still consume their trial-number slot.** A generation may contain fewer than `population_size` completed trials. When the previous generation does not have exactly `population_size` completed trials, the DE update for that step is skipped and sampling falls back accordingly.
-
 
 ## Installation
 

--- a/package/samplers/differential_evolution/de.py
+++ b/package/samplers/differential_evolution/de.py
@@ -291,6 +291,25 @@ class DESampler(optunahub.samplers.SimpleBaseSampler):
     def _get_generation_trials(self, study: optuna.study.Study, generation: int) -> list:
         """Get all completed trials for a specific generation.
 
+        A trial's generation is defined as ``trial.number // population_size`` (see
+        :meth:`sample_relative`). A naive implementation materializes the study's entire
+        trial history on every call, so its cost grows with the total number of trials
+        recorded so far rather than with the ``population_size`` trials actually needed.
+        Over a full run this makes the amortized per-trial sampling overhead grow with the
+        study size.
+
+        Instead, only the bounded, study-local block of trials that realizes
+        ``generation`` is retrieved. Because a trial's generation is
+        ``trial.number // population_size``, generation ``g`` corresponds to the trial
+        numbers ``[g * pop, (g + 1) * pop)``, which are looked up through the study-scoped
+        ``(study_id, number)`` API. This uses study-local numbers only, so it is unaffected
+        by the storage-global trial id being offset or interleaved by other studies sharing
+        the same storage.
+
+        The retrieved trials are then filtered exactly as before (``COMPLETE`` state and a
+        matching stored generation attribute), so the returned list -- including its
+        ordering by trial number -- is identical to the full-scan behavior.
+
         Args:
             study:
                 Optuna study object.
@@ -299,17 +318,37 @@ class DESampler(optunahub.samplers.SimpleBaseSampler):
 
         Returns:
             list:
-                A list of completed trials for the specified generation.
+                A list of completed trials for the specified generation, ordered by
+                trial number.
         """
-        all_trials = study.get_trials(deepcopy=False)
-        return [
-            t
-            for t in all_trials
+        if not isinstance(self.population_size, int):
+            raise ValueError("Population size must be resolved to an integer before this point.")
+
+        storage = study._storage
+        study_id = study._study_id
+
+        # A trial's generation is ``trial.number // population_size`` (see
+        # :meth:`sample_relative`), so generation ``g`` is realized by the study-local
+        # trial numbers ``[g * pop, (g + 1) * pop)``. Fetch only that bounded block
+        # instead of scanning the whole history.
+        start = generation * self.population_size
+        end = start + self.population_size
+
+        generation_trials: list[optuna.trial.FrozenTrial] = []
+        for number in range(start, end):
+            try:
+                trial_id = storage.get_trial_id_from_study_id_trial_number(study_id, number)
+            except KeyError:
+                # This generation is not fully recorded yet; no further trials exist.
+                break
+            trial = storage.get_trial(trial_id)
             if (
-                t.state == optuna.trial.TrialState.COMPLETE
-                and t.system_attrs.get("differential_evolution:generation") == generation
-            )
-        ]
+                trial.state == optuna.trial.TrialState.COMPLETE
+                and trial.system_attrs.get("differential_evolution:generation") == generation
+            ):
+                generation_trials.append(trial)
+
+        return generation_trials
 
     def reseed_rng(self) -> None:
         """Reseed the random number generator for the sampler."""
@@ -383,9 +422,12 @@ class DESampler(optunahub.samplers.SimpleBaseSampler):
                 "Population size must be an integer before initializing trial vectors."
             )
 
-        # Calculate current generation and individual index
-        current_generation = trial._trial_id // self.population_size
-        individual_index = trial._trial_id % self.population_size
+        # Calculate current generation and individual index from the study-local trial
+        # number so that generations map to a study's own 0-based trial blocks and do not
+        # depend on the storage-global trial id (which may be offset or interleaved by
+        # other studies sharing the same storage).
+        current_generation = trial.number // self.population_size
+        individual_index = trial.number % self.population_size
 
         # Store generation and individual info as trial attributes
         study._storage.set_trial_system_attr(

--- a/package/samplers/differential_evolution/de.py
+++ b/package/samplers/differential_evolution/de.py
@@ -82,7 +82,24 @@ class DESampler(optunahub.samplers.SimpleBaseSampler):
             Last processed generation.
         current_gen_vectors:
             Trial vectors for the current generation.
-    """
+
+    Generation semantics:
+        A trial's generation is defined by study-local trial creation order::
+
+            generation = trial.number // population_size
+
+        This is intentional and has consequences worth noting:
+
+        - Generation boundaries are **not** completion barriers. Under
+          asynchronous execution (``n_jobs > 1``), trials in generation ``g + 1``
+          may be sampled before every trial in generation ``g`` has completed, so
+          a generation is not guaranteed to be sampled from the fully updated
+          population of the previous generation.
+        - Failed or pruned trials still consume their trial-number slot, so a
+          generation may contain fewer than ``population_size`` completed trials.
+          When a previous generation does not have exactly ``population_size``
+          completed trials, the DE update for that step is skipped and sampling
+          falls back accordingly."""
 
     def __init__(
         self,

--- a/package/samplers/differential_evolution/tests/test_generation_retrieval.py
+++ b/package/samplers/differential_evolution/tests/test_generation_retrieval.py
@@ -236,5 +236,44 @@ def test_retrieval_touches_only_generation_sized_set_independent_of_history() ->
     assert calls_small == calls_large
 
 
+def test_generation_semantics_slot_gaps_and_no_completion_barrier() -> None:
+    # Makes the generation invariant explicit (as requested in review):
+    # (1) FAIL/PRUNED trials consume their trial-number slot, so a generation can
+    #     hold fewer than population_size completed trials; and
+    # (2) generation boundaries are not completion barriers -- a later generation
+    #     can be fully present while an earlier one is left under-filled.
+    population_size = 5
+    sampler = DESampler(population_size=population_size, seed=0)
+    study = optuna.create_study(direction="minimize", sampler=sampler, storage=InMemoryStorage())
+    dist = FloatDistribution(-5.0, 5.0)
+
+    # Generation 0 (numbers 0..4): #2 FAIL, #3 PRUNED -> only 3 completed.
+    # Generation 1 (numbers 5..9): all completed.
+    non_complete = {2: TrialState.FAIL, 3: TrialState.PRUNED}
+    for number in range(10):
+        state = non_complete.get(number, TrialState.COMPLETE)
+        study.add_trial(
+            create_trial(
+                state=state,
+                value=float(number) if state == TrialState.COMPLETE else None,
+                params={"x": float(number % 7) - 3.0},
+                distributions={"x": dist},
+                system_attrs={_GENERATION_KEY: number // population_size},
+            )
+        )
+
+    gen0 = sampler._get_generation_trials(study, 0)
+    gen1 = sampler._get_generation_trials(study, 1)
+
+    # (1) Under-filled generation: fewer than population_size completed trials.
+    assert [t.number for t in gen0] == [0, 1, 4]
+    assert len(gen0) < population_size
+
+    # (2) No completion barrier: the later generation is fully present even though
+    #     the earlier one never reached population_size completed trials.
+    assert [t.number for t in gen1] == [5, 6, 7, 8, 9]
+    assert len(gen1) == population_size
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/package/samplers/differential_evolution/tests/test_generation_retrieval.py
+++ b/package/samplers/differential_evolution/tests/test_generation_retrieval.py
@@ -1,0 +1,240 @@
+"""Tests for the bounded, study-local generation retrieval in ``DESampler``.
+
+``DESampler._get_generation_trials`` used to materialize the study's entire trial
+history on every generation boundary, which made the per-generation sampling cost grow
+with the total number of trials in the study. These tests pin down the optimized
+retrieval: that it returns exactly the same trials (and ordering) as the original
+full-scan behavior, that it keeps excluding non-``COMPLETE`` trials, that it stays
+correct when trial IDs are offset or interleaved by other studies sharing the same
+storage, and that it touches only a generation-sized set of trials regardless of how
+large the study grows.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import optuna
+from optuna.distributions import FloatDistribution
+from optuna.storages import BaseStorage
+from optuna.storages import InMemoryStorage
+from optuna.trial import create_trial
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+import optunahub
+import pytest
+
+
+DESampler = optunahub.load_local_module(
+    package="samplers/differential_evolution",
+    registry_root="package/",
+).DESampler
+
+_GENERATION_KEY = "differential_evolution:generation"
+
+
+def _full_scan_reference(study: optuna.study.Study, generation: int) -> list[FrozenTrial]:
+    """Reference implementation: the original full-history scan and filter."""
+    all_trials = study.get_trials(deepcopy=False)
+    return [
+        t
+        for t in all_trials
+        if t.state == TrialState.COMPLETE and t.system_attrs.get(_GENERATION_KEY) == generation
+    ]
+
+
+def _objective(trial: optuna.trial.Trial) -> float:
+    x = trial.suggest_float("x", -5.0, 5.0)
+    y = trial.suggest_float("y", -5.0, 5.0)
+    return x**2 + y**2
+
+
+def _run_study(
+    population_size: int = 8,
+    n_trials: int = 40,
+    storage: BaseStorage | None = None,
+    study_name: str | None = None,
+) -> tuple[optuna.study.Study, Any]:
+    sampler = DESampler(population_size=population_size, seed=42)
+    study = optuna.create_study(
+        direction="minimize", sampler=sampler, storage=storage, study_name=study_name
+    )
+    study.optimize(_objective, n_trials=n_trials)
+    return study, sampler
+
+
+def _observed_generations(study: optuna.study.Study) -> list[int]:
+    gens = {
+        t.system_attrs[_GENERATION_KEY]
+        for t in study.get_trials(deepcopy=False)
+        if _GENERATION_KEY in t.system_attrs
+    }
+    return sorted(gens)
+
+
+def test_matches_full_scan_including_ordering() -> None:
+    # The optimized retrieval must return the same trials, in the same order, as a scan
+    # of the entire history for every generation the study produced.
+    population_size = 8
+    study, sampler = _run_study(population_size=population_size, n_trials=48)
+
+    generations = _observed_generations(study)
+    assert len(generations) >= 3  # ensure the study actually spans multiple generations
+
+    for generation in generations:
+        expected = _full_scan_reference(study, generation)
+        actual = sampler._get_generation_trials(study, generation)
+
+        # Same set and ordering (ordering feeds population-indexed fitness/selection).
+        assert [t._trial_id for t in actual] == [t._trial_id for t in expected]
+        assert [t.number for t in actual] == [t.number for t in expected]
+        assert [t.value for t in actual] == [t.value for t in expected]
+        assert all(t.state == TrialState.COMPLETE for t in actual)
+
+
+def test_excludes_failed_and_pruned_trials() -> None:
+    # A generation whose block contains FAIL/PRUNED trials must return only the COMPLETE
+    # ones, identically to the full-history scan.
+    population_size = 5
+    sampler = DESampler(population_size=population_size, seed=0)
+    study = optuna.create_study(direction="minimize", sampler=sampler, storage=InMemoryStorage())
+    dist = FloatDistribution(-5.0, 5.0)
+
+    # Three full generations (numbers 0..14), with a repeating COMPLETE/FAIL/PRUNED mix
+    # so that every generation contains at least one non-COMPLETE trial.
+    states = [
+        TrialState.COMPLETE,
+        TrialState.COMPLETE,
+        TrialState.COMPLETE,
+        TrialState.FAIL,
+        TrialState.PRUNED,
+    ]
+    for number in range(15):
+        state = states[number % len(states)]
+        # Fresh InMemory study -> trial_id offset is 0, so number == trial_id here.
+        study.add_trial(
+            create_trial(
+                state=state,
+                value=float(number) if state == TrialState.COMPLETE else None,
+                params={"x": float(number % 7) - 3.0},
+                distributions={"x": dist},
+                system_attrs={_GENERATION_KEY: number // population_size},
+            )
+        )
+
+    for generation in range(3):
+        expected = _full_scan_reference(study, generation)
+        actual = sampler._get_generation_trials(study, generation)
+        assert [t._trial_id for t in actual] == [t._trial_id for t in expected]
+        assert all(t.state == TrialState.COMPLETE for t in actual)
+        # Sanity: some non-COMPLETE trials really were present in this generation's block.
+        assert len(actual) < population_size
+
+
+def test_correct_with_shared_storage_trial_id_offset() -> None:
+    # Trial IDs come from a storage-global counter. When another study occupies the first
+    # trial IDs, this study's trials are offset (trial.number != trial._trial_id). The
+    # retrieval must still return exactly what the full scan returns.
+    population_size = 8
+    storage = InMemoryStorage()
+
+    prior = optuna.create_study(storage=storage, study_name="prior")
+    prior.optimize(lambda t: t.suggest_float("z", 0.0, 1.0), n_trials=7)
+
+    study, sampler = _run_study(
+        population_size=population_size,
+        n_trials=40,
+        storage=storage,
+        study_name="de",
+    )
+
+    # Confirm the offset is genuinely non-zero, i.e. the test exercises the offset path.
+    offset = storage.get_trial_id_from_study_id_trial_number(study._study_id, 0)
+    assert offset != 0
+
+    generations = _observed_generations(study)
+    assert len(generations) >= 3
+    for generation in generations:
+        expected = _full_scan_reference(study, generation)
+        actual = sampler._get_generation_trials(study, generation)
+        assert [t._trial_id for t in actual] == [t._trial_id for t in expected]
+        assert [t.number for t in actual] == [t.number for t in expected]
+
+
+def test_correct_with_interleaved_shared_storage() -> None:
+    # Two studies write trials into one storage in an interleaved order, so a single
+    # study's global trial IDs are no longer contiguous (trial.number != trial._trial_id
+    # and the gaps are irregular). Because generations are defined on the study-local
+    # trial number, retrieval must still match the full scan, and each fully populated
+    # generation must contain exactly population_size completed trials.
+    population_size = 8
+    storage = InMemoryStorage()
+
+    sampler_a = DESampler(population_size=population_size, seed=1)
+    sampler_b = DESampler(population_size=population_size, seed=2)
+    study_a = optuna.create_study(
+        direction="minimize", sampler=sampler_a, storage=storage, study_name="a"
+    )
+    study_b = optuna.create_study(
+        direction="minimize", sampler=sampler_b, storage=storage, study_name="b"
+    )
+
+    # Alternate one trial at a time so the two studies' trial IDs interleave in storage.
+    for _ in range(5 * population_size):
+        study_a.optimize(_objective, n_trials=1)
+        study_b.optimize(_objective, n_trials=1)
+
+    # The interleaving must actually make this study's IDs non-contiguous.
+    numbers_to_ids = {t.number: t._trial_id for t in study_a.get_trials(deepcopy=False)}
+    assert any(numbers_to_ids[n] != n for n in numbers_to_ids)
+
+    generations = _observed_generations(study_a)
+    assert len(generations) >= 3
+    for generation in generations:
+        expected = _full_scan_reference(study_a, generation)
+        actual = sampler_a._get_generation_trials(study_a, generation)
+        assert [t._trial_id for t in actual] == [t._trial_id for t in expected]
+        assert [t.number for t in actual] == [t.number for t in expected]
+
+    # A later, fully populated generation must hold exactly population_size trials, i.e.
+    # generation bookkeeping stays well-formed under interleaving.
+    assert len(sampler_a._get_generation_trials(study_a, generations[-2])) == population_size
+
+
+def test_retrieval_touches_only_generation_sized_set_independent_of_history() -> None:
+    # Regression guard for the scaling fix, without wall-clock assertions: the number of
+    # per-trial storage fetches for one generation must be bounded by population_size and
+    # must not grow as the study accumulates more generations.
+    population_size = 8
+    sampler = DESampler(population_size=population_size, seed=1)
+    study = optuna.create_study(direction="minimize", sampler=sampler, storage=InMemoryStorage())
+
+    def count_get_trial_calls(target_generation: int) -> int:
+        storage = study._storage
+        with patch.object(storage, "get_trial", wraps=storage.get_trial) as spy_get_trial:
+            with patch.object(
+                storage, "get_all_trials", wraps=storage.get_all_trials
+            ) as spy_get_all:
+                sampler._get_generation_trials(study, target_generation)
+        # The full-history path must not be used at all.
+        assert spy_get_all.call_count == 0
+        return int(spy_get_trial.call_count)
+
+    # Grow the study and measure the cost of retrieving the SAME early generation as the
+    # total number of trials increases. A history-scanning implementation would touch more
+    # trials as the study grows; the bounded implementation must not.
+    study.optimize(_objective, n_trials=3 * population_size)
+    calls_small = count_get_trial_calls(target_generation=1)
+
+    study.optimize(_objective, n_trials=9 * population_size)
+    calls_large = count_get_trial_calls(target_generation=1)
+
+    assert calls_small <= population_size
+    assert calls_large <= population_size
+    # The essential scaling property: retrieval cost is independent of the study size.
+    assert calls_small == calls_large
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

Fixes #405.

`DESampler._get_generation_trials()` is called once per generation boundary and runs `study.get_trials(deepcopy=False)`, which materializes and returns *every* trial recorded in the study so far, then filters down to the ~`population_size` trials of the target generation in Python. Its cost therefore scales with the total number of trials in the study rather than with the population size, so per-generation retrieval grows roughly linearly with N (a full run is ~O(N²/population_size)).

This was independently confirmed at the function level on real JournalStorage studies (see @hevertfernandes' benchmark in the thread): timing `_get_generation_trials()` on frozen studies of 17k / 30k / 60k trials, the current sampler grows ~3.0× across that range while this PR stays flat.

Note: the original issue also reported an end-to-end throughput decay; on follow-up profiling that decay turned out to be dominated by other per-trial costs (e.g. a `gc.collect()` in the user's objective), not this scan. The scaling issue fixed here is real and worth removing on its own merits, but this PR should be evaluated on the function-level scaling benchmark rather than that original throughput report.

## Description of the changes

Retrieve only the bounded, study-local block of trials that realizes the requested generation instead of scanning the whole history.

Because a trial's generation is `trial.number // population_size`, generation `g` is exactly the study-local trial numbers `[g * pop, (g + 1) * pop)`. These are fetched through the study-scoped `(study_id, trial_number)` storage API (`get_trial_id_from_study_id_trial_number` + `get_trial`), which are O(1) lookups on the in-memory, RDB, and Journal backends, and then filtered exactly as before (`COMPLETE` state and matching stored generation attribute). Returned trials keep their trial-number ordering, so the result is identical to the previous full-scan for the common single-study case.

**Note on a small, deliberate semantics change:** to make the bounded lookup sound, generation and individual indexing in `sample_relative()` now use the study-local `trial.number` instead of the storage-global `trial._trial_id`:

```python
current_generation = trial.number // self.population_size
individual_index   = trial.number % self.population_size
```

For a fresh single study `trial.number == trial._trial_id`, so this does not change behavior (the full existing test suite, including the reproducibility tests, passes unchanged). The two only differ when trial IDs are offset or interleaved by other studies sharing one storage; there, defining generations on the study-local number is the well-defined choice and keeps the sampler's bookkeeping consistent with the retrieval. This is intentionally included because the retrieval and the generation definition must agree; it is not a separate redesign of the algorithm.

### Performance

Per-boundary retrieval time, full-scan vs. bounded (equivalent results at every N):

| Trials (N) | JournalStorage full-scan | bounded | SQLite full-scan | bounded  |
|-----------:|-------------------------:|--------:|-----------------:|---------:|
| 1,000      | 0.19 ms                  | 0.37 ms | 1.19 ms          | 0.026 ms |
| 8,000      | 1.17 ms                  | 0.37 ms | 2.48 ms          | 0.025 ms |
| 30,000     | 6.20 ms                  | 0.35 ms | 9.19 ms          | 0.023 ms |

Full-scan grows linearly with N; bounded retrieval stays flat.

### Tests

New `tests/test_generation_retrieval.py` adds:
- equivalence with the previous full-scan, including trial ordering;
- correct exclusion of `FAIL`/`PRUNED` trials;
- correctness under a non-zero trial-ID offset (a prior study sharing the storage);
- correctness under interleaved writes from two studies sharing one storage;
- a deterministic scaling guard that asserts retrieval touches only a generation-sized set of trials and never calls the full-history path, without relying on wall-clock timing.

All existing tests, the 5 new tests, Ruff, and strict mypy pass.
