### PR TITLE
Adopt to Optuna 5.0 and add metric/constraint names

### DIFF
--- a/package/benchmarks/hpa/README.md
+++ b/package/benchmarks/hpa/README.md
@@ -3,7 +3,7 @@ author: Optuna Team
 title: Single and Multi-objective Optimization Benchmark Problems Focusing on Human-Powered Aircraft Design
 description: The benchmark problem for human-powered aircraft design introduced in the paper `Single and Multi-Objective Optimization Benchmark Problems Focusing on Human-Powered Aircraft Design`
 tags: [benchmark, HPA, multi-objective, human-powered aircraft]
-optuna_versions: [4.1.0]
+optuna_versions: [5.0.0]
 license: MIT License
 ---
 
@@ -29,16 +29,59 @@ Note that `Problem` also receives the same set of arguments.
   - Returns: `dict[str, optuna.distributions.BaseDistribution]`
 - `directions`: Return the optimization directions.
   - Returns: `list[optuna.study.StudyDirection]`
+- `metric_names`: Return the objective names in the order returned by `evaluate`.
+  - Returns: `list[str]` of length `self.nf`.
+- `constraint_names`: Return the constraint names used as the keys of `evaluate_constraints`. This property is only available in `ConstrainedProblem`.
+  - Returns: `list[str]` of length `self.ng`.
 - `evaluate(params: dict[str, float])`: Evaluate the objective function given a dictionary of parameters.
   - Args:
     - `params`: A dictionary representing decision variable like `{"x0": x1_value, "x1": x1_value, ..., "xn": xn_value}`. The number of parameters must be equal to `self.nx`. `xn_value` must be a `float` in `[0, 1]`.
   - Returns: List of length `self.nf`.
-- `evaluate_constraints(params: dict[str, float])`: Evaluate the constraint functions and return the list of constraint functions values. This method is only available in `ConstrainedProblem`.
+- `evaluate_constraints(params: dict[str, float])`: Evaluate the constraint functions and return the constraint function values keyed by their names. This method is only available in `ConstrainedProblem`.
   - Args:
     - `params`: A dictionary representing the decision variables, with the same format and value range as in evaluate.
-  - Returns: List of length `self.ng`.
+  - Returns: Dictionary of length `self.ng`. A trial is feasible when every value is zero or less.
 
 The properties and functions of classes in [`hpa.problem`](https://hub.optuna.org/benchmarks/hpa/hpa_original) are also available such as `nx`.
+
+## Objective and Constraint Names
+
+Each problem uses a subset of the 11 fundamental objectives and the 5 constraints defined in Table 1 of the paper.
+The names below carry the paper's `f_i` and `g_j` indices as a prefix, so `metric_names` and `constraint_names` can be read directly against Table 2 of the paper.
+Which subset a problem uses can also be inspected at runtime via `problem.metric_names` and `problem.constraint_names`.
+
+### Objectives (all minimized)
+
+Since the paper maximizes the cruise speed, the wing efficiency, and the payload, the corresponding objectives are negated and prefixed with `negative_`.
+
+| Name                          | Paper                                       | Unit |
+| ----------------------------- | ------------------------------------------- | ---- |
+| `f1_required_power`           | $f_1 = P$                                   | W    |
+| `f2_drag`                     | $f_2 = D$                                   | N    |
+| `f3_negative_cruise_speed`    | $f_3 = -V$                                  | m/s  |
+| `f4_max_wingtip_deflection`   | $f_4 = \max(\|\delta\|, \|\delta_{park}\|)$ | m    |
+| `f5_max_twist_angle`          | $f_5 = \Phi$                                | deg  |
+| `f6_negative_wing_efficiency` | $f_6 = -E$                                  | -    |
+| `f7_empty_weight`             | $f_7 = W_0$                                 | kg   |
+| `f8_wing_span`                | $f_8 = B$                                   | m    |
+| `f9_root_angle_of_attack`     | $f_9 = \alpha_0$                            | deg  |
+| `f10_wire_tension`            | $f_{10} = T$                                | N    |
+| `f11_negative_payload`        | $f_{11} = -W_p$                             | kg   |
+
+### Constraints (feasible when zero or less)
+
+| Name                           | Paper                                           | Unit |
+| ------------------------------ | ----------------------------------------------- | ---- |
+| `g1_max_strain`                | $g_1 = n_m n_s \epsilon_{max} / \epsilon_u - 1$ | -    |
+| `g2_wingtip_dihedral_angle`    | $g_2 = B (\sin\gamma - \sin\gamma_u) / 2$       | m    |
+| `g3_parked_wingtip_deflection` | $g_3 = -\delta_{park}$                          | m    |
+| `g4_required_power`            | $g_4 = P - P_{max}$                             | W    |
+| `g5_min_cruise_speed`          | $g_5 = 1 - (V / V_{min})^3$                     | -    |
+
+Note that `evaluate_constraints` preserves the order of the original implementation, which is not sorted by the constraint index.
+For example, `ConstrainedProblem("HPA131").constraint_names` is `["g1_max_strain", "g3_parked_wingtip_deflection", "g2_wingtip_dihedral_angle"]`.
+
+In the unconstrained problems, the constraints are folded into the objectives as penalty terms following Eq. (5) of the paper, so `Problem` exposes only `metric_names`.
 
 ## Installation
 

--- a/package/benchmarks/hpa/_hpa.py
+++ b/package/benchmarks/hpa/_hpa.py
@@ -86,6 +86,106 @@ unconstrained_problems: dict[str, type[BaseUnconstrainedHPABenchmark]] = {
     name: getattr(problem, name) for name in hpa_benchmark_names if name[-2] == "0"
 }
 
+# The 11 fundamental objectives and the 5 constraints of Table 1 in the paper
+# (https://arxiv.org/abs/2312.08953). The keys are the indices of `f_i` and `g_j` in the paper.
+# `negative_` is prefixed to the quantities that the paper maximizes, because the original
+# implementation negates them so that every objective is minimized.
+_OBJECTIVE_NAMES: dict[int, str] = {
+    1: "f1_required_power",  # P [W]
+    2: "f2_drag",  # D [N]
+    3: "f3_negative_cruise_speed",  # -V [m/s]
+    4: "f4_max_wingtip_deflection",  # max(|delta|, |delta_park|) [m]
+    5: "f5_max_twist_angle",  # Phi [deg]
+    6: "f6_negative_wing_efficiency",  # -E [-]
+    7: "f7_empty_weight",  # W_0 [kg]
+    8: "f8_wing_span",  # B [m]
+    9: "f9_root_angle_of_attack",  # alpha_0 [deg]
+    10: "f10_wire_tension",  # T [N]
+    11: "f11_negative_payload",  # -W_p [kg]
+}
+_CONSTRAINT_NAMES: dict[int, str] = {
+    1: "g1_max_strain",  # n_m * n_s * eps_max / eps_u - 1 [-]
+    2: "g2_wingtip_dihedral_angle",  # B * (sin(gamma) - sin(gamma_u)) / 2 [m]
+    3: "g3_parked_wingtip_deflection",  # -delta_park [m]
+    4: "g4_required_power",  # P - P_max [W]
+    5: "g5_min_cruise_speed",  # 1 - (V / V_min)^3 [-]
+}
+
+# Table 2 in the paper lists the objectives of a constrained problem and of its unconstrained
+# counterpart in the same row, e.g. HPA131 and HPA101, so each row below names both problems.
+# The indices follow the order in which the original implementation returns the objectives.
+_OBJECTIVE_INDICES_TABLE: list[tuple[tuple[int, ...], tuple[str, ...]]] = [
+    ((2,), ("HPA131", "HPA101")),
+    ((1,), ("HPA142", "HPA102")),
+    ((3,), ("HPA143", "HPA103")),
+    ((1, 3), ("HPA241", "HPA201")),
+    ((1, 4), ("HPA222", "HPA202")),
+    ((2, 11), ("HPA233", "HPA203")),
+    ((3, 5), ("HPA244", "HPA204")),
+    ((3, 10), ("HPA245", "HPA205")),
+    ((1, 3, 6), ("HPA341", "HPA301")),
+    ((1, 4, 5), ("HPA322", "HPA302")),
+    ((2, 9, 11), ("HPA333", "HPA303")),
+    ((2, 3, 5), ("HPA344", "HPA304")),
+    ((1, 3, 10), ("HPA345", "HPA305")),
+    ((2, 3, 5, 7), ("HPA441", "HPA401")),
+    ((1, 4, 5, 8), ("HPA422", "HPA402")),
+    ((3, 6, 7, 10), ("HPA443", "HPA403")),
+    ((2, 3, 5, 6, 7), ("HPA541", "HPA501")),
+    ((1, 3, 9, 10, 11), ("HPA542", "HPA502")),
+    ((1, 3, 5, 6, 7, 8), ("HPA641", "HPA601")),
+    ((1, 3, 5, 6, 7, 8, 9, 10, 11), ("HPA941", "HPA901")),
+]
+
+# Constrained problems share only four distinct constraint sets. The indices follow the order in
+# which the original implementation returns the constraints, which is not sorted by the index.
+_CONSTRAINT_INDICES_TABLE: list[tuple[tuple[int, ...], tuple[str, ...]]] = [
+    ((1, 3, 2), ("HPA131", "HPA233", "HPA333")),
+    ((1, 5), ("HPA222", "HPA322", "HPA422")),
+    ((1, 3, 2, 5), ("HPA142",)),
+    (
+        (1, 3, 2, 4),
+        (
+            "HPA143",
+            "HPA241",
+            "HPA244",
+            "HPA245",
+            "HPA341",
+            "HPA344",
+            "HPA345",
+            "HPA441",
+            "HPA443",
+            "HPA541",
+            "HPA542",
+            "HPA641",
+            "HPA941",
+        ),
+    ),
+]
+
+_OBJECTIVE_INDICES: dict[str, tuple[int, ...]] = {
+    problem_name: indices
+    for indices, problem_names in _OBJECTIVE_INDICES_TABLE
+    for problem_name in problem_names
+}
+_CONSTRAINT_INDICES: dict[str, tuple[int, ...]] = {
+    problem_name: indices
+    for indices, problem_names in _CONSTRAINT_INDICES_TABLE
+    for problem_name in problem_names
+}
+
+
+def _build_metric_names(problem_name: str, n_objectives: int) -> list[str]:
+    names = [_OBJECTIVE_NAMES[i] for i in _OBJECTIVE_INDICES[problem_name]]
+    assert len(names) == n_objectives, f"{problem_name} must have {n_objectives} objectives."
+    return names
+
+
+def _build_constraint_names(problem_name: str, n_constraints: int) -> list[str]:
+    names = [_CONSTRAINT_NAMES[i] for i in _CONSTRAINT_INDICES[problem_name]]
+    assert len(names) == n_constraints, f"{problem_name} must have {n_constraints} constraints."
+    return names
+
 
 class Problem(optunahub.benchmarks.BaseProblem):
     def __init__(self, problem_name: str, n_div: int = 4, level: int = 0) -> None:
@@ -117,6 +217,7 @@ class Problem(optunahub.benchmarks.BaseProblem):
         self._search_space = {
             f"x{i}": optuna.distributions.FloatDistribution(0, 1) for i in range(self._problem.nx)
         }
+        self._metric_names = _build_metric_names(problem_name, self._problem.nf)
 
     @property
     def search_space(self) -> dict[str, optuna.distributions.BaseDistribution]:
@@ -128,6 +229,11 @@ class Problem(optunahub.benchmarks.BaseProblem):
         """Return the optimization directions."""
         return [optuna.study.StudyDirection.MINIMIZE] * self._problem.nf
 
+    @property
+    def metric_names(self) -> list[str]:
+        """Return the objective names in the order returned by ``evaluate``."""
+        return self._metric_names.copy()
+
     def evaluate(self, params: dict[str, float]) -> list[float]:
         return self._problem([params[name] for name in self._search_space]).tolist()
 
@@ -135,7 +241,7 @@ class Problem(optunahub.benchmarks.BaseProblem):
         return getattr(self._problem, name)
 
 
-class ConstrainedProblem(optunahub.benchmarks.ConstrainedMixin, optunahub.benchmarks.BaseProblem):
+class ConstrainedProblem(optunahub.benchmarks.BaseProblem):
     def __init__(self, problem_name: str, n_div: int = 4, level: int = 0) -> None:
         """Initialize the problem.
         Args:
@@ -165,6 +271,8 @@ class ConstrainedProblem(optunahub.benchmarks.ConstrainedMixin, optunahub.benchm
         self._search_space = {
             f"x{i}": optuna.distributions.FloatDistribution(0, 1) for i in range(self._problem.nx)
         }
+        self._metric_names = _build_metric_names(problem_name, self._problem.nf)
+        self._constraint_names = _build_constraint_names(problem_name, self._problem.ng)
 
     @property
     def search_space(self) -> dict[str, optuna.distributions.BaseDistribution]:
@@ -176,14 +284,25 @@ class ConstrainedProblem(optunahub.benchmarks.ConstrainedMixin, optunahub.benchm
         """Return the optimization directions."""
         return [optuna.study.StudyDirection.MINIMIZE] * self._problem.nf
 
+    @property
+    def metric_names(self) -> list[str]:
+        """Return the objective names in the order returned by ``evaluate``."""
+        return self._metric_names.copy()
+
+    @property
+    def constraint_names(self) -> list[str]:
+        """Return the constraint names used as the keys of ``evaluate_constraints``."""
+        return self._constraint_names.copy()
+
     def evaluate(self, params: dict[str, float]) -> list[float]:
         return self._problem([params[name] for name in self._search_space])[0].tolist()
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._problem, name)
 
-    def evaluate_constraints(self, params: dict[str, float]) -> list[float]:
-        return self._problem([params[name] for name in self._search_space])[1].tolist()
+    def evaluate_constraints(self, params: dict[str, float]) -> dict[str, float]:
+        values = self._problem([params[name] for name in self._search_space])[1].tolist()
+        return dict(zip(self._constraint_names, values))
 
 
 if TYPE_CHECKING:

--- a/package/benchmarks/hpa/requirements.txt
+++ b/package/benchmarks/hpa/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 scipy
-optunahub
+optunahub>=0.5
+optuna>=5.0


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

This PR adopts HPA to the new interface.
Plus, add the metric/constraint names from the paper.