### PR TITLE
Add JANUS samplers (single-objective and multi-objective)

### DIFF
--- a/package/samplers/janus/LICENSE
+++ b/package/samplers/janus/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hongyuan Yu, Pufan Xu, Jiaojiao Yi, Yiding Tian, Mingrui Sun, Jiayuan Lu, Changyuan Wen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/samplers/janus/README.md
+++ b/package/samplers/janus/README.md
@@ -1,0 +1,105 @@
+---
+author: Hongyuan Yu, Pufan Xu, Jiaojiao Yi, Yiding Tian, Mingrui Sun, Jiayuan Lu, Changyuan Wen
+title: JANUS Sampler
+description: A CMA-ES sampler augmented with JANUS Jacobian-aligned Gauss-Newton exploitation and inverse-curvature exploration for single-objective black-box optimization.
+tags: [sampler, CMA-ES, Gauss-Newton, evolutionary algorithm, evotorch]
+optuna_versions: [4.5.0]
+license: MIT License
+---
+
+## Abstract
+
+`JanusSampler` is a single-objective, plug-and-play sampler that augments a CMA-ES host (evotorch backend) with JANUS-style, geometry-guided candidate generation (arXiv:2608.22862). It is the single-objective counterpart of `JanusMooCmixSampler`.
+
+Population optimizers such as CMA-ES drive search through rank-based selection: the signal says one candidate is better than another, but not the local *direction* responsible for the improvement. JANUS recovers this missing geometric signal from a single estimated Jacobian `J` and uses it for **both** halves of the search, without replacing the host optimizer:
+
+- **Exploit** — a bounded Gauss-Newton / Levenberg–Marquardt step `Δ = −(JᵀJ + λI)⁻¹ Jᵀ s` is assembled from the recent trace and injected as one elite child (whitened step norm clipped to `κ√d`).
+- **Explore (CMIX)** — the *same* curvature metric produces a tail of inverse-curvature candidates `x ~ N(mean, σ² · trace_normalize((JᵀJ + λ_mix I)⁻¹))`, adding targeted low-curvature exploration while CMA-ES keeps its native covariance adaptation.
+
+The Jacobian is estimated directly from a per-trial residual/component vector when available (recommended, exposed via `trial.set_user_attr("component_losses", [...])`); otherwise JANUS falls back to a local linear/quadratic fit on the recent window of scalar objective values.
+
+## APIs
+
+- `JanusSampler(x0=None, sigma0=None, seed=None, cma_opts=None, n_startup_trials=1, independent_sampler=None, warn_independent_sampling=True, n_jobs=1, fuse_every=4, fuse_start="auto", kappa=1.0, gn_window="auto", gn_lambda=1.0, gn_ridge=1.0, cmix_w="auto", cmix_lambda=1.0, cmix_w_base=0.5, cmix_w_min=0.01, cmix_w_max=0.20, pseudo_mode="linear", gn_pseudo_mode=None, cmix_pseudo_mode=None, pseudo_target="raw", pca_k="auto", cmix_mode="portfolio", cmix_candidate_frac=0.4, cmix_candidate_center="mean", cmix_candidate_cov="metric", verbose=False)`
+  - `x0`: Initial mean per parameter. If `None`, the search-space midpoint is used.
+  - `sigma0`: Initial step size. Defaults to `0.2` when `None`.
+  - `seed`: Seed for the random number generators. A random seed is drawn if `None`.
+  - `cma_opts`: Extra CMA-ES options; `cma_opts["popsize"]` overrides the default population size.
+  - `n_startup_trials`: Number of completed trials required before JANUS activates; earlier trials are drawn from `independent_sampler`.
+  - `independent_sampler`: Sampler used for non-relative parameters and startup. Defaults to `RandomSampler`.
+  - `warn_independent_sampling`: Whether to warn when parameters are sampled independently.
+  - `n_jobs`: Number of parallel CMA-ES states keyed by `trial.number % n_jobs`.
+  - `fuse_every`: Assemble a fresh Gauss-Newton elite/metric every this many generations.
+  - `fuse_start`: Warm-up before the first fuse. `"auto"` derives it from population size and window.
+  - `kappa`: Trust-region cap on the whitened elite step (`‖z‖ ≤ κ√d`).
+  - `gn_window`: Sliding window of recent trials used to estimate `J`. `"auto"` adapts to the residual dimension.
+  - `gn_lambda`: Levenberg–Marquardt damping for the Gauss-Newton step.
+  - `gn_ridge`: Ridge regularization for the Jacobian regression.
+  - `cmix_w`: Weight of the inverse-curvature blend into the covariance when `cmix_mode="reshape"`. `"auto"` scales with how overdetermined the regression is.
+  - `cmix_lambda`: Damping added to the metric before inversion for CMIX.
+  - `cmix_w_base`, `cmix_w_min`, `cmix_w_max`: Bounds and base used to resolve `cmix_w="auto"`.
+  - `pseudo_mode`: Local surrogate used when no residual vector is available (`"linear"`, `"quadratic"`, `"diag_quadratic"`, `"pca_quadratic"`, `"diag_pca_quadratic"`).
+  - `gn_pseudo_mode`, `cmix_pseudo_mode`: Per-half overrides of `pseudo_mode`.
+  - `pseudo_target`: Target transform for the surrogate fit (`"raw"`, `"rank"`, `"log"`).
+  - `pca_k`: Number of PCA components for PCA-quadratic surrogates. `"auto"` derives it from the sample count and dimension.
+  - `cmix_mode`: How CMIX is applied (`"portfolio"`, `"candidates"`, `"reshape"`).
+  - `cmix_candidate_frac`: Fraction of the population replaced by CMIX candidates.
+  - `cmix_candidate_center`: Center of the CMIX distribution (`"mean"`, `"best"`, `"elite"`, `"archive"`).
+  - `cmix_candidate_cov`: Covariance source for CMIX candidates.
+  - `verbose`: If `True`, prints periodic diagnostics.
+
+JANUS only samples non-conditional numerical (`FloatDistribution` / `IntDistribution`) parameters through the relative CMA-ES host; categorical and conditional parameters fall back to the independent sampler.
+
+## Installation
+
+This sampler requires the optional backend `torch` and `evotorch`:
+
+```shell
+pip install torch evotorch
+```
+
+## Example
+
+```python
+import numpy as np
+import optuna
+import optunahub
+
+
+def objective(trial: optuna.Trial) -> float:
+    x = np.array([trial.suggest_float(f"x{i}", -5.0, 5.0) for i in range(10)])
+    residuals = (x - 0.5) ** 2
+    # Optional: expose per-coordinate residuals so JANUS can estimate J directly.
+    trial.set_user_attr("component_losses", residuals.tolist())
+    return float(residuals.sum())
+
+
+JanusSampler = optunahub.load_module(package="samplers/janus").JanusSampler
+
+sampler = JanusSampler(seed=0, n_startup_trials=16)
+study = optuna.create_study(direction="minimize", sampler=sampler)
+study.optimize(objective, n_trials=300)
+print(f"Best value: {study.best_value:.6e}")
+```
+
+See `example.py` for a runnable version.
+
+## Others
+
+This sampler is the single-objective component of JANUS (Jacobian-Aligned Newton-Unified Search). See the `janus_moo` package for the multi-objective (NSGA-II) counterpart.
+
+### Reference
+
+Hongyuan Yu, Pufan Xu, Jiaojiao Yi, Yiding Tian, Mingrui Sun, Jiayuan Lu, and Changyuan Wen. 2026. JANUS: Online Jacobian-Aligned Infill for Black-Box Optimization. arXiv preprint arXiv:2608.22862.
+
+### Bibtex
+
+```
+@article{yu2026janus,
+    title   = {JANUS: Online Jacobian-Aligned Infill for Black-Box Optimization},
+    author  = {Yu, Hongyuan and Xu, Pufan and Yi, Jiaojiao and Tian, Yiding and
+               Sun, Mingrui and Lu, Jiayuan and Wen, Changyuan},
+    journal = {arXiv preprint arXiv:2608.22862},
+    year    = {2026}
+}
+```

--- a/package/samplers/janus/__init__.py
+++ b/package/samplers/janus/__init__.py
@@ -1,0 +1,4 @@
+from .janus import JanusSampler
+
+
+__all__ = ["JanusSampler"]

--- a/package/samplers/janus/example.py
+++ b/package/samplers/janus/example.py
@@ -1,0 +1,54 @@
+"""Single-objective JANUS example.
+
+``JanusSampler`` is a drop-in relative sampler backed by a CMA-ES host
+(evotorch backend). Every few generations it injects a Gauss-Newton exploitation
+candidate plus inverse-curvature (CMIX) exploration candidates estimated from the
+recent evaluation trace.
+
+Optional but recommended: expose a per-trial residual/component vector via
+``trial.set_user_attr("component_losses", [...])``. When present, JANUS estimates
+the local Jacobian directly from these residuals; otherwise it falls back to a
+local linear/quadratic fit on the recent window of scalar objective values.
+
+This example requires the optional backend (see ``requirements.txt``):
+``torch`` and ``evotorch``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import optuna
+import optunahub
+
+
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+
+def objective(trial: optuna.Trial) -> float:
+    # A 10-D shifted sphere with an explicit residual decomposition.
+    d = 10
+    shift = 0.5
+    x = np.array([trial.suggest_float(f"x{i}", -5.0, 5.0) for i in range(d)])
+    residuals = (x - shift) ** 2  # per-coordinate residuals r_i(x)
+
+    # Exposing residuals lets JANUS estimate the local Jacobian directly.
+    trial.set_user_attr("component_losses", residuals.tolist())
+
+    return float(residuals.sum())
+
+
+if __name__ == "__main__":
+    JanusSampler = optunahub.load_local_module(
+        package="samplers/janus",
+        registry_root="./package",
+    ).JanusSampler
+
+    sampler = JanusSampler(seed=0, n_startup_trials=16)
+    study = optuna.create_study(direction="minimize", sampler=sampler)
+    study.optimize(objective, n_trials=300)
+
+    print(f"Best value: {study.best_value:.6e}")
+    print(
+        "Best params (first 3):",
+        {k: round(v, 4) for k, v in list(study.best_params.items())[:3]},
+    )

--- a/package/samplers/janus/janus.py
+++ b/package/samplers/janus/janus.py
@@ -1,0 +1,1069 @@
+"""
+JANUS sampler (evotorch backend).
+
+Unified Gauss-Newton metric framework: ONE estimated Jacobian J drives BOTH
+halves of the search.
+
+  EXPLOIT (unchanged from mosaic_gn): a GN/LM elite
+      Δ = −(JᵀJ + λI)⁻¹ Jᵀ s,  x_b + tΔ
+  is assembled and BOUNDED-injected (whitened step ‖z‖ clipped to κ√d).
+
+  EXPLORE (CMIX): the SAME GN curvature metric creates a
+  tail of inverse-curvature candidates:
+      T  = (JᵀJ + λ_mix I)⁻¹
+      x_tail ~ N(mean, σ² · trace_normalize(T))
+  This keeps CMA's native covariance adaptation intact while adding targeted
+  low-curvature exploration.
+
+IMPORTANT — w is an ABSOLUTE weight, not w_fac·c1. The report's "w ≈ 2·c1 sweet
+spot" was tuned at low dim; at AWB's d=1135 evotorch's c_1 ≈ 1.55e-6, so w_fac·c1
+would blend essentially nothing. cmix_w defaults to 0.02 (dimension-robust).
+
+cmix reuses the JᵀJ computed during the GN assembly the SAME generation, so there
+is no extra Jacobian estimation. Defaults use GN+CMIX with adaptive fuse_start
+and gn_window, popsize supplied by cma_opts when needed, and 40% candidate
+budgets. Requires per-trial component_losses (or rae) as the residual vector r.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import logging as _py_logging
+import math
+import random
+from typing import Any
+
+import numpy as np
+import optuna
+from optuna import logging
+from optuna._imports import try_import
+from optuna.distributions import BaseDistribution
+from optuna.distributions import CategoricalDistribution
+from optuna.distributions import FloatDistribution
+from optuna.distributions import IntDistribution
+from optuna.samplers import BaseSampler
+from optuna.search_space import IntersectionSearchSpace
+from optuna.study import StudyDirection
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+
+
+with try_import() as _imports:
+    from evotorch import Problem
+    from evotorch.algorithms import CMAES
+    from evotorch.algorithms.cmaes import _h_sig
+    import torch
+
+
+for _n in ("evotorch", "evotorch.core"):
+    _py_logging.getLogger(_n).setLevel(_py_logging.WARNING)
+
+_logger = logging.get_logger(__name__)
+_EPS = 1e-10
+
+
+def dynamic_normalize_params(
+    params: dict[str, Any],
+    norm_min: float = 0,
+    norm_max_range: list[float] = [1, 2],
+) -> dict[str, Any]:
+    low, high = params["low"], params["high"]
+    step = params.get("step", None)
+    original_range = high - low
+    best: dict[str, Any] = {"nm": None, "sf": None, "st": None}
+    min_dp = float("inf")
+    for nm in [
+        x * 0.01 for x in range(int(norm_max_range[0] * 100), int(norm_max_range[1] * 100) + 1)
+    ]:
+        sf = (nm - norm_min) / original_range
+        dp = len(str(sf).split(".")[1]) if "." in str(sf) else 0
+        if dp < min_dp:
+            min_dp = dp
+            best = {"nm": nm, "sf": sf, "st": round(step * sf, 10) if step else None}
+    return {"low": norm_min, "high": best["nm"], "step": best["st"], "scale": best["sf"]}
+
+
+def resolve_pca_k(pca_k: int | str, n: int, d: int, min_extra: int = 10) -> int:
+    if isinstance(pca_k, str) and pca_k.lower() == "auto":
+        budget = max(1, n - int(min_extra))
+        q_sample = int((math.sqrt(1.0 + 8.0 * budget) - 3.0) // 2)
+        q_dim = int(math.ceil(math.sqrt(float(d))))
+        return int(max(1, min(d, q_sample, q_dim)))
+    return int(max(1, min(int(pca_k), d)))
+
+
+def _pseudo_target(f: np.ndarray, target: str = "raw") -> np.ndarray:
+    f = np.asarray(f, dtype=float).reshape(-1)
+    target = str(target or "raw").lower()
+    if target in ("rank", "ranks", "rank_normalized"):
+        order = np.argsort(f)
+        ranks = np.empty_like(order, dtype=float)
+        ranks[order] = np.arange(f.size, dtype=float)
+        if f.size > 1:
+            ranks = ranks / float(f.size - 1)
+        return ranks - float(np.mean(ranks))
+    if target in ("log", "log_shift", "log1p"):
+        shift = float(np.min(f))
+        y = np.log1p(np.maximum(f - shift, 0.0))
+        return y - float(np.mean(y))
+    return f - float(np.mean(f))
+
+
+def _standardize(X: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    mu = X.mean(axis=0)
+    sd = X.std(axis=0) + 1e-9
+    return (X - mu) / sd, mu, sd
+
+
+def _positive_hessian_metric(
+    H: np.ndarray, mode: str, fit_r2: float = 0.0
+) -> dict[str, Any] | None:
+    H = 0.5 * (np.asarray(H, dtype=float) + np.asarray(H, dtype=float).T)
+    if not np.all(np.isfinite(H)):
+        return None
+    try:
+        evals, evecs = np.linalg.eigh(H)
+    except np.linalg.LinAlgError:
+        return None
+    pos = evals > max(float(np.max(np.abs(evals))), 1.0) * 1e-10
+    if not np.any(pos):
+        return None
+    lam = evals[pos]
+    V = evecs[:, pos]
+    JtJ = V @ np.diag(lam) @ V.T
+    return {
+        "JtJ": 0.5 * (JtJ + JtJ.T),
+        "mode": mode,
+        "rank": int(lam.size),
+        "fit_r2": float(fit_r2),
+    }
+
+
+def _linear_pseudo(
+    Z: np.ndarray, y: np.ndarray, sd: np.ndarray, ridge: float
+) -> dict[str, Any] | None:
+    n, d = Z.shape
+    try:
+        w = np.linalg.solve(Z.T @ Z + float(ridge) * np.eye(d), Z.T @ y)
+    except np.linalg.LinAlgError:
+        return None
+    if not np.all(np.isfinite(w)):
+        return None
+    g = w / sd
+    JtJ = np.outer(g, g)
+    return {"JtJ": JtJ, "mode": "linear", "rank": 1, "fit_r2": 0.0}
+
+
+def _fit_full_quadratic(
+    Z: np.ndarray, y: np.ndarray, sd: np.ndarray, ridge: float
+) -> dict[str, Any] | None:
+    n, d = Z.shape
+    iu = np.triu_indices(d)
+    Phi = np.concatenate([Z, Z[:, iu[0]] * Z[:, iu[1]]], axis=1)
+    if n < Phi.shape[1] + 2:
+        return None
+    try:
+        coef = np.linalg.solve(Phi.T @ Phi + float(ridge) * np.eye(Phi.shape[1]), Phi.T @ y)
+    except np.linalg.LinAlgError:
+        return None
+    if not np.all(np.isfinite(coef)):
+        return None
+    yhat = Phi @ coef
+    sst = float(np.sum(y**2))
+    fit_r2 = 0.0 if sst <= _EPS else max(0.0, 1.0 - float(np.sum((y - yhat) ** 2)) / sst)
+    hvec = coef[d:]
+    H_std = np.zeros((d, d), dtype=float)
+    H_std[iu] = hvec
+    H_std = H_std + H_std.T
+    inv_sd = 1.0 / sd
+    H = H_std * inv_sd[:, None] * inv_sd[None, :]
+    return _positive_hessian_metric(H, "quadratic", fit_r2=fit_r2)
+
+
+def _fit_diag_quadratic(
+    Z: np.ndarray, y: np.ndarray, sd: np.ndarray, ridge: float
+) -> dict[str, Any] | None:
+    n, d = Z.shape
+    if n < 2 * d + 10:
+        return None
+    Phi = np.concatenate([Z, Z * Z], axis=1)
+    try:
+        coef = np.linalg.solve(Phi.T @ Phi + float(ridge) * np.eye(2 * d), Phi.T @ y)
+    except np.linalg.LinAlgError:
+        return None
+    if not np.all(np.isfinite(coef)):
+        return None
+    yhat = Phi @ coef
+    sst = float(np.sum(y**2))
+    fit_r2 = 0.0 if sst <= _EPS else max(0.0, 1.0 - float(np.sum((y - yhat) ** 2)) / sst)
+    hdiag = np.maximum(2.0 * coef[d:] / (sd * sd), 0.0)
+    if not np.any(hdiag > 0):
+        return None
+    return {
+        "JtJ": np.diag(hdiag),
+        "mode": "diag_quadratic",
+        "rank": int(np.count_nonzero(hdiag > 0)),
+        "fit_r2": float(fit_r2),
+    }
+
+
+def _fit_pca_quadratic(
+    Z: np.ndarray, y: np.ndarray, sd: np.ndarray, pca_k: int | str, ridge: float
+) -> dict[str, Any] | None:
+    n, d = Z.shape
+    if isinstance(pca_k, str) and pca_k.lower() in ("none", "off", "false", "0"):
+        return None
+    if not isinstance(pca_k, str) and int(pca_k) <= 0:
+        return None
+    q = int(max(1, min(resolve_pca_k(pca_k, n, d, min_extra=10), n - 2)))
+    try:
+        _, _, vt = np.linalg.svd(Z, full_matrices=False)
+    except np.linalg.LinAlgError:
+        return None
+    if vt.shape[0] < q:
+        return None
+    basis = vt[:q].T
+    U = Z @ basis
+    iu = np.triu_indices(q)
+    Phi = np.concatenate([U, U[:, iu[0]] * U[:, iu[1]]], axis=1)
+    if n < Phi.shape[1] + 2:
+        return None
+    try:
+        coef = np.linalg.solve(Phi.T @ Phi + float(ridge) * np.eye(Phi.shape[1]), Phi.T @ y)
+    except np.linalg.LinAlgError:
+        return None
+    if not np.all(np.isfinite(coef)):
+        return None
+    yhat = Phi @ coef
+    sst = float(np.sum(y**2))
+    fit_r2 = 0.0 if sst <= _EPS else max(0.0, 1.0 - float(np.sum((y - yhat) ** 2)) / sst)
+    hvec = coef[q:]
+    H_sub = np.zeros((q, q), dtype=float)
+    H_sub[iu] = hvec
+    H_sub = H_sub + H_sub.T
+    H_std = basis @ H_sub @ basis.T
+    inv_sd = 1.0 / sd
+    H = H_std * inv_sd[:, None] * inv_sd[None, :]
+    out = _positive_hessian_metric(H, "pca_quadratic", fit_r2=fit_r2)
+    if out is not None:
+        out["q"] = int(q)
+    return out
+
+
+def pseudo_metric(
+    X: np.ndarray,
+    f: np.ndarray,
+    mode: str = "linear",
+    ridge: float = 1.0,
+    pca_k: int | str = "auto",
+    target: str = "raw",
+) -> dict[str, Any] | None:
+    X = np.asarray(X, dtype=float)
+    f = np.asarray(f, dtype=float).reshape(-1)
+    if X.ndim != 2 or f.ndim != 1 or X.shape[0] != f.shape[0]:
+        return None
+    finite = np.all(np.isfinite(X), axis=1) & np.isfinite(f)
+    X = X[finite]
+    f = f[finite]
+    if X.shape[0] < 4 or X.shape[1] <= 0:
+        return None
+    Z, _mu, sd = _standardize(X)
+    y = _pseudo_target(f, target=target)
+    mode = str(mode or "linear").lower()
+
+    def linear() -> dict[str, Any] | None:
+        return _linear_pseudo(Z, y, sd, ridge)
+
+    if mode in ("none", "off", "false"):
+        return None
+    if mode in ("linear", "lin"):
+        return linear()
+    if mode in ("quadratic", "quad"):
+        return _fit_full_quadratic(Z, y, sd, ridge) or linear()
+    if mode in ("diag_quadratic", "diagq", "diagonal_quadratic"):
+        return _fit_diag_quadratic(Z, y, sd, ridge) or linear()
+    if mode in ("pca_quadratic", "pcaq"):
+        return _fit_pca_quadratic(Z, y, sd, pca_k, ridge) or linear()
+    if mode in ("diag_pca_quadratic", "diag_pcaq", "diagpca"):
+        diag = _fit_diag_quadratic(Z, y, sd, ridge)
+        pca = _fit_pca_quadratic(Z, y, sd, pca_k, ridge)
+        if diag is None and pca is None:
+            return linear()
+        if diag is None:
+            return pca
+        if pca is None or pca.get("mode") == "linear":
+            return diag
+        JtJ = diag["JtJ"] + pca["JtJ"]
+        return {
+            "JtJ": 0.5 * (JtJ + JtJ.T),
+            "mode": "diag_pca_quadratic",
+            "rank": int(diag.get("rank", 0) + pca.get("rank", 0)),
+            "fit_r2": max(float(diag.get("fit_r2", 0.0)), float(pca.get("fit_r2", 0.0))),
+            "q": pca.get("q"),
+        }
+    return linear()
+
+
+class JanusSampler(BaseSampler):
+    """JANUS: GN exploit injection + candidate inverse-curvature CMIX exploration."""
+
+    def __init__(
+        self,
+        x0: dict[str, Any] | None = None,
+        sigma0: float | None = None,
+        seed: int | None = None,
+        cma_opts: dict[str, Any] | None = None,
+        n_startup_trials: int = 1,
+        independent_sampler: BaseSampler | None = None,
+        warn_independent_sampling: bool = True,
+        n_jobs: int = 1,
+        fuse_every: int = 4,
+        fuse_start: int | str = "auto",
+        kappa: float = 1.0,
+        gn_window: int | str = "auto",
+        gn_lambda: float = 1.0,
+        gn_ridge: float = 1.0,
+        cmix_w: float | str = "auto",
+        cmix_lambda: float = 1.0,
+        cmix_w_base: float = 0.5,
+        cmix_w_min: float = 0.01,
+        cmix_w_max: float = 0.20,
+        pseudo_mode: str = "linear",
+        gn_pseudo_mode: str | None = None,
+        cmix_pseudo_mode: str | None = None,
+        pseudo_target: str = "raw",
+        pca_k: int | str = "auto",
+        cmix_mode: str = "portfolio",
+        cmix_candidate_frac: float = 0.4,
+        cmix_candidate_center: str = "mean",
+        cmix_candidate_cov: str = "metric",
+        verbose: bool = False,
+    ) -> None:
+        _imports.check()
+        self._verbose = bool(verbose)
+        self._x0 = x0
+        self._sigma0 = sigma0
+        if seed is None:
+            seed = random.randint(1, 2**31 - 1)
+        self._seed = seed
+        self._cma_opts = cma_opts or {}
+        self._n_startup_trials = n_startup_trials
+        self._independent_sampler = independent_sampler or optuna.samplers.RandomSampler(seed=seed)
+        self._warn_independent_sampling = warn_independent_sampling
+        self._search_space = IntersectionSearchSpace()
+        self._n_jobs = n_jobs
+        self._fuse_every = fuse_every
+        self._fuse_start = fuse_start
+        self._kappa = kappa
+        self._gn_window = gn_window
+        self._gn_lambda = gn_lambda
+        self._gn_ridge = gn_ridge
+        self._cmix_w = cmix_w
+        self._cmix_lambda = cmix_lambda
+        self._cmix_w_base = cmix_w_base
+        self._cmix_w_min = cmix_w_min
+        self._cmix_w_max = cmix_w_max
+        self._pseudo_mode = pseudo_mode
+        self._gn_pseudo_mode = gn_pseudo_mode or pseudo_mode
+        self._cmix_pseudo_mode = cmix_pseudo_mode or pseudo_mode
+        self._pseudo_target = pseudo_target
+        self._pca_k = pca_k
+        self._cmix_mode = cmix_mode
+        self._cmix_candidate_frac = cmix_candidate_frac
+        self._cmix_candidate_center = cmix_candidate_center
+        self._cmix_candidate_cov = cmix_candidate_cov
+        self.optimizer_dict: dict[int, _JanusOptimizer] = {}
+
+    def reseed_rng(self) -> None:
+        self._seed = random.randint(1, 2**31 - 1)
+        self._independent_sampler.reseed_rng()
+
+    def infer_relative_search_space(
+        self, study: optuna.study.Study, trial: FrozenTrial
+    ) -> dict[str, BaseDistribution]:
+        return {n: d for n, d in self._search_space.calculate(study).items() if not d.single()}
+
+    def sample_independent(
+        self,
+        study: optuna.study.Study,
+        trial: FrozenTrial,
+        param_name: str,
+        param_distribution: BaseDistribution,
+    ) -> Any:
+        self._raise_error_if_multi_objective(study)
+        return self._independent_sampler.sample_independent(
+            study, trial, param_name, param_distribution
+        )
+
+    def sample_relative(
+        self,
+        study: optuna.study.Study,
+        trial: FrozenTrial,
+        search_space: dict[str, BaseDistribution],
+    ) -> dict[str, Any]:
+        self._raise_error_if_multi_objective(study)
+        if len(search_space) <= 1:
+            return {}
+        completed = self._get_trials(study)
+        if len(completed) < self._n_startup_trials:
+            return {}
+        if self._x0 is None:
+            x0: dict[str, Any] = {}
+            for n, d in search_space.items():
+                if isinstance(d, IntDistribution):
+                    x0[n] = int(np.mean([d.high, d.low]))
+                elif isinstance(d, FloatDistribution):
+                    x0[n] = float(np.mean([d.high, d.low]))
+                elif isinstance(d, CategoricalDistribution):
+                    x0[n] = d.choices[(len(d.choices) - 1) // 2]
+            self._x0 = x0
+        if self._sigma0 is None:
+            self._sigma0 = 0.2
+        popsize = self._cma_opts.get("popsize") or (4 + int(3 * math.log(len(search_space))))
+        thread_id = trial.number % self._n_jobs
+
+        opt = self.optimizer_dict.get(thread_id)
+        if opt is None:
+            opt = _JanusOptimizer(
+                search_space,
+                completed,
+                study.direction,
+                self._x0,
+                self._sigma0,
+                self._cma_opts,
+                self._seed + thread_id,
+                self._fuse_every,
+                self._fuse_start,
+                self._kappa,
+                self._gn_window,
+                self._gn_lambda,
+                self._gn_ridge,
+                self._cmix_w,
+                self._cmix_lambda,
+                self._cmix_w_base,
+                self._cmix_w_min,
+                self._cmix_w_max,
+                self._pseudo_mode,
+                self._gn_pseudo_mode,
+                self._cmix_pseudo_mode,
+                self._pseudo_target,
+                self._pca_k,
+                self._cmix_mode,
+                self._cmix_candidate_frac,
+                self._cmix_candidate_center,
+                self._cmix_candidate_cov,
+                self._verbose,
+            )
+        else:
+            opt._completed_trials = completed
+        opt._update_es()
+        self.optimizer_dict[thread_id] = opt
+        return opt.ask(trial.number % popsize)
+
+    def before_trial(self, study: optuna.study.Study, trial: FrozenTrial) -> None:
+        self._independent_sampler.before_trial(study, trial)
+
+    def after_trial(
+        self,
+        study: optuna.study.Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Sequence[float] | None,
+    ) -> None:
+        self._independent_sampler.after_trial(study, trial, state, values)
+
+    def _get_trials(self, study: optuna.study.Study) -> list[FrozenTrial]:
+        return [
+            t
+            for t in study._get_trials(deepcopy=False, use_cache=True)
+            if t.state == TrialState.COMPLETE
+        ]
+
+
+class _JanusOptimizer:
+    def __init__(
+        self,
+        search_space: dict[str, BaseDistribution],
+        completed_trials: list[FrozenTrial],
+        study_direction: StudyDirection,
+        x0: dict[str, Any],
+        sigma0: float,
+        cma_opts: dict[str, Any],
+        seed: int,
+        fuse_every: int,
+        fuse_start: int | str,
+        kappa: float,
+        gn_window: int | str,
+        gn_lambda: float,
+        gn_ridge: float,
+        cmix_w: float | str,
+        cmix_lambda: float,
+        cmix_w_base: float = 0.5,
+        cmix_w_min: float = 0.01,
+        cmix_w_max: float = 0.20,
+        pseudo_mode: str = "linear",
+        gn_pseudo_mode: str | None = None,
+        cmix_pseudo_mode: str | None = None,
+        pseudo_target: str = "raw",
+        pca_k: int | str = "auto",
+        cmix_mode: str = "candidates",
+        cmix_candidate_frac: float = 0.05,
+        cmix_candidate_center: str = "mean",
+        cmix_candidate_cov: str = "metric",
+        verbose: bool = False,
+    ) -> None:
+        self._verbose = bool(verbose)
+        self._search_space = search_space
+        self._param_names = list(sorted(search_space.keys()))
+        self._study_direction = study_direction
+        self._completed_trials = completed_trials
+        self._fuse_every = fuse_every
+        self._fuse_start = fuse_start
+        self._kappa = kappa
+        self._gn_window = gn_window
+        self._gn_lambda = gn_lambda
+        self._gn_ridge = gn_ridge
+        self._cmix_w = cmix_w  # may be "auto" until first GN assembly resolves it
+        self._cmix_lambda = cmix_lambda
+        self._cmix_w_base = cmix_w_base
+        self._cmix_w_min = cmix_w_min
+        self._cmix_w_max = cmix_w_max
+        self._pseudo_mode = pseudo_mode
+        self._gn_pseudo_mode = gn_pseudo_mode or pseudo_mode
+        self._cmix_pseudo_mode = cmix_pseudo_mode or pseudo_mode
+        self._pseudo_target = pseudo_target
+        self._pca_k = pca_k
+        self._cmix_mode = str(cmix_mode or "candidates").lower()
+        self._cmix_candidate_frac = float(cmix_candidate_frac)
+        self._cmix_candidate_center = str(cmix_candidate_center or "mean").lower()
+        self._cmix_candidate_cov = str(cmix_candidate_cov or "metric").lower()
+        self.trials_used: list[int] = []
+        self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self._rng = np.random.default_rng(int(seed) % (2**32 - 1))
+        self._archive_cursor = 0
+
+        self._param_transforms: dict[str, dict[str, Any]] = {}
+        for name in self._param_names:
+            dist = search_space[name]
+            if isinstance(dist, (FloatDistribution, IntDistribution)):
+                norm = dynamic_normalize_params(
+                    {"low": dist.low, "high": dist.high, "step": dist.step}
+                )
+                self._param_transforms[name] = {
+                    "bias": dist.low,
+                    "scale": norm["scale"],
+                    "low": norm["low"],
+                    "high": norm["high"],
+                }
+        d = len(self._param_names)
+        self._d = d
+        self._sqrt_d = math.sqrt(d)
+        self._popsize = cma_opts.get("popsize") or (4 + int(3 * math.log(d)))
+
+        lo = np.array([self._param_transforms[n]["low"] for n in self._param_names], float)
+        hi = np.array([self._param_transforms[n]["high"] for n in self._param_names], float)
+        self._lo_t = torch.tensor(lo, dtype=torch.float, device=self._device)
+        self._hi_t = torch.tensor(hi, dtype=torch.float, device=self._device)
+        self._lo_np = lo
+        self._hi_np = hi
+        init_mean = (self._lo_t + self._hi_t) / 2.0
+        stdev_init = max(float(((self._hi_t - self._lo_t) / 6.0).min().item()), _EPS)
+
+        torch.manual_seed(int(seed) % (2**31 - 1))
+        self._problem = Problem(
+            "min",
+            objective_func=None,
+            initial_bounds=(self._lo_t, self._hi_t),
+            solution_length=d,
+            device=self._device,
+        )
+        self._es = CMAES(
+            self._problem,
+            stdev_init=stdev_init,
+            center_init=init_mean,
+            popsize=self._popsize,
+            limit_C_decomposition=True,
+        )
+
+        self._generation = 0
+        self._pending_xs: Any = None
+        self._win_x: list[np.ndarray] = []
+        self._win_r: list[np.ndarray] = []
+        self._win_f: list[float] = []
+        self._seen: set[int] = set()
+        self._n_injected = 0
+        self._last_clip = 0.0
+        self._gn_fail = 0
+        self._last_JtJ: np.ndarray | None = None  # numpy [d,d], set fresh each GN assembly
+        self._last_pseudo_mode: str | None = None
+        self._pca_hits = 0
+        self._pca_fail = 0
+        self._n_cmix = 0
+        self._cmix_fail = 0
+        self._cmix_w_eff: float | None = None  # resolved numeric weight (set when m is known)
+
+    def _resolve_cmix_w(self, m: int) -> float:
+        """Resolve cmix_w to a numeric weight. 'auto' scales with how overdetermined
+        the Jacobian regression is: w = w_base · min(m, window) / d, clipped.
+        At AWB (m=111, window=300, d=1135): 0.5·111/1135 ≈ 0.049."""
+        if self._cmix_w_eff is not None:
+            return self._cmix_w_eff
+        if isinstance(self._cmix_w, str) and self._cmix_w.lower() == "auto":
+            r = float(min(m, self._resolve_gn_window(m)))
+            w = self._cmix_w_base * r / float(self._d)
+            auto_min = self._cmix_w_base / float(self._d)
+            w = float(min(max(w, auto_min), self._cmix_w_max))
+        else:
+            w = float(self._cmix_w)
+        self._cmix_w_eff = w
+        return w
+
+    def _resolve_gn_window(self, m: int | None = None) -> int:
+        setting = self._gn_window
+        if not (isinstance(setting, str) and setting.lower() == "auto"):
+            return int(max(self._popsize, setting))
+        min_window = max(4 * self._popsize, 80)
+        if m is None:
+            target = max(min_window, 300)
+        else:
+            target = max(min_window, 3 * int(m))
+        return int(min(max(target, min_window), 1200))
+
+    def _resolve_fuse_start(self, window: int) -> int:
+        setting = self._fuse_start
+        if not (isinstance(setting, str) and setting.lower() == "auto"):
+            return int(max(self._popsize, min(int(setting), window)))
+        return int(max(2 * self._popsize, min(200, max(self._popsize, window // 2))))
+
+    def _harvest(self) -> None:
+        for t in self._completed_trials:
+            if t.number in self._seen:
+                continue
+            rae = (
+                (t.user_attrs.get("component_losses") or t.user_attrs.get("rae"))
+                if t.user_attrs
+                else None
+            )
+            if rae is None:
+                continue
+            try:
+                x = np.array([self._to_cma(n, t.params[n]) for n in self._param_names], float)
+            except Exception:
+                continue
+            fval = float(t.value) if t.value is not None else float(np.mean(rae))
+            if t.value is not None and self._study_direction == StudyDirection.MAXIMIZE:
+                fval = -fval
+            self._win_x.append(x)
+            self._win_r.append(np.asarray(rae, float))
+            self._win_f.append(fval)
+            self._seen.add(t.number)
+        m = len(self._win_r[-1]) if self._win_r else None
+        window = self._resolve_gn_window(m)
+        if len(self._win_x) > window:
+            self._win_x = self._win_x[-window:]
+            self._win_r = self._win_r[-window:]
+            self._win_f = self._win_f[-window:]
+
+    # ---- GN/LM elite + cache JᵀJ for CMIX ----
+    def _assemble_gn(self) -> np.ndarray | None:
+        self._last_JtJ = None
+        if self._win_r:
+            window = self._resolve_gn_window(len(self._win_r[-1]))
+        else:
+            window = self._resolve_gn_window(None)
+        fuse_start = self._resolve_fuse_start(window)
+        if len(self._win_x) < max(fuse_start, self._popsize):
+            return None
+        X = np.array(self._win_x)
+        R = np.array(self._win_r)
+        if R.ndim != 2 or R.shape[0] != X.shape[0]:
+            return None
+        S = np.sqrt(np.maximum(R, 0.0))
+        d = self._d
+        self._resolve_cmix_w(S.shape[1])
+        mu = X.mean(0)
+        sd = X.std(0) + 1e-9
+        Z = (X - mu) / sd
+        try:
+            AinvZt = np.linalg.solve(Z.T @ Z + self._gn_ridge * np.eye(d), Z.T)
+        except np.linalg.LinAlgError:
+            self._gn_fail += 1
+            return None
+        Sc = S - S.mean(0)
+        W = (AinvZt @ Sc).T
+        J = W / sd[None, :]
+        gn_JtJ = J.T @ J
+        pseudo = pseudo_metric(
+            X,
+            np.asarray(self._win_f, dtype=float),
+            mode=self._gn_pseudo_mode,
+            ridge=self._gn_ridge,
+            pca_k=self._pca_k,
+            target=self._pseudo_target,
+        )
+        use_pseudo = pseudo is not None and str(pseudo.get("mode", "linear")) != "linear"
+        if use_pseudo:
+            assert pseudo is not None
+            self._last_JtJ = np.asarray(pseudo["JtJ"], dtype=float)
+            self._last_pseudo_mode = str(pseudo.get("mode"))
+            if "pca" in self._last_pseudo_mode:
+                self._pca_hits += 1
+        else:
+            self._last_JtJ = gn_JtJ
+            self._last_pseudo_mode = "gn_residual"
+            if "pca" in str(self._gn_pseudo_mode).lower():
+                self._pca_fail += 1
+        ib = int(np.argmin(R.mean(1)))
+        x_b = X[ib]
+        s_b = S[ib]
+        H = self._last_JtJ + self._gn_lambda * np.eye(d)
+        try:
+            if use_pseudo:
+                y = _pseudo_target(
+                    np.asarray(self._win_f, dtype=float), target=self._pseudo_target
+                )
+                g = np.linalg.solve(Z.T @ Z + self._gn_ridge * np.eye(d), Z.T @ y) / sd
+                delta = -np.linalg.solve(H, g)
+            else:
+                delta = -np.linalg.solve(H, J.T @ s_b)
+        except np.linalg.LinAlgError:
+            self._gn_fail += 1
+            return None
+        if not np.all(np.isfinite(delta)):
+            self._gn_fail += 1
+            return None
+        best_t, best_pred = 1.0, np.inf
+        for step in (0.25, 0.5, 1.0):
+            if use_pseudo:
+                pred = float(
+                    self._win_f[ib]
+                    + step * np.dot(g, delta)
+                    + 0.5 * step * step * np.dot(delta, self._last_JtJ @ delta)
+                )
+            else:
+                pred = float(np.sum((s_b + step * (J @ delta)) ** 2))
+            if pred < best_pred:
+                best_pred, best_t = pred, step
+        elite = x_b + best_t * delta
+        return np.clip(elite, self._lo_np, self._hi_np)
+
+    def _candidate_metric(self) -> tuple[np.ndarray, np.ndarray] | None:
+        if self._last_JtJ is None:
+            return None
+        if self._cmix_pseudo_mode != self._gn_pseudo_mode and self._win_x:
+            cmix_pseudo = pseudo_metric(
+                np.asarray(self._win_x, dtype=float),
+                np.asarray(self._win_f, dtype=float),
+                mode=self._cmix_pseudo_mode,
+                ridge=self._gn_ridge,
+                pca_k=self._pca_k,
+                target=self._pseudo_target,
+            )
+            if cmix_pseudo is not None and str(cmix_pseudo.get("mode", "linear")) != "linear":
+                self._last_JtJ = np.asarray(cmix_pseudo["JtJ"], dtype=float)
+                self._last_pseudo_mode = str(cmix_pseudo.get("mode"))
+                if "pca" in self._last_pseudo_mode:
+                    self._pca_hits += 1
+        d = self._d
+        try:
+            metric = np.linalg.inv(self._last_JtJ + self._cmix_lambda * np.eye(d))
+        except np.linalg.LinAlgError:
+            self._cmix_fail += 1
+            return None
+        if not np.all(np.isfinite(metric)):
+            self._cmix_fail += 1
+            return None
+        metric = 0.5 * (metric + metric.T)
+        try:
+            eigvals, eigvecs = np.linalg.eigh(metric)
+        except np.linalg.LinAlgError:
+            self._cmix_fail += 1
+            return None
+        if not np.all(np.isfinite(eigvals)):
+            self._cmix_fail += 1
+            return None
+        eigvals = np.maximum(eigvals, 1e-12)
+        C = self._es.C.detach().cpu().numpy().astype(np.float64)
+        trC = float(np.trace(C))
+        trM = float(np.sum(eigvals))
+        if trC <= 0.0 or trM <= 0.0 or not np.isfinite(trC):
+            self._cmix_fail += 1
+            return None
+        eigvals = eigvals * (trC / trM)
+        return eigvecs, eigvals
+
+    def _archive_centers(self, count: int) -> list[np.ndarray]:
+        if count <= 0 or not self._win_x or not self._win_r:
+            return []
+        R = np.asarray(self._win_r, dtype=float)
+        X = np.asarray(self._win_x, dtype=float)
+        if R.ndim != 2 or X.ndim != 2 or R.shape[0] != X.shape[0]:
+            return []
+        finite = np.all(np.isfinite(R), axis=1) & np.all(np.isfinite(X), axis=1)
+        if not np.any(finite):
+            return []
+        R = R[finite]
+        X = X[finite]
+        order = np.argsort(np.mean(R, axis=1), kind="mergesort")[
+            : min(R.shape[0], max(200, 8 * count))
+        ]
+        R = R[order]
+        X = X[order]
+        keep = np.ones(R.shape[0], dtype=bool)
+        for i in range(R.shape[0]):
+            if not keep[i]:
+                continue
+            dominated = np.all(R <= R[i], axis=1) & np.any(R < R[i], axis=1)
+            dominated[i] = False
+            keep[dominated] = False
+        archive_x = X[keep]
+        archive_r = R[keep]
+        if archive_x.shape[0] == 0:
+            return []
+        if archive_x.shape[0] > 1:
+            lo = np.min(archive_r, axis=0)
+            hi = np.max(archive_r, axis=0)
+            norm_r = (archive_r - lo) / np.maximum(hi - lo, 1e-12)
+            selected = [int(np.argmin(np.mean(norm_r, axis=1)))]
+            while len(selected) < min(count, archive_x.shape[0]):
+                dist = np.min(
+                    np.linalg.norm(
+                        norm_r[:, None, :] - norm_r[np.asarray(selected)][None, :, :], axis=2
+                    ),
+                    axis=1,
+                )
+                dist[np.asarray(selected)] = -1.0
+                selected.append(int(np.argmax(dist)))
+            archive_x = archive_x[np.asarray(selected)]
+        centers = [
+            archive_x[(self._archive_cursor + i) % archive_x.shape[0]] for i in range(count)
+        ]
+        self._archive_cursor = (self._archive_cursor + count) % max(1, archive_x.shape[0])
+        return centers
+
+    def _cmix_candidate_samples(self, count: int, elite_np: np.ndarray | None = None) -> Any:
+        if count <= 0 or self._last_JtJ is None:
+            return None
+        metric = self._candidate_metric()
+        if metric is None:
+            return None
+        eigvecs, eigvals = metric
+        if self._cmix_candidate_center == "archive":
+            centers = self._archive_centers(count)
+            if centers:
+                scale = float(max(self._es.sigma, _EPS))
+                samples_list = []
+                for center in centers:
+                    noise = self._rng.normal(size=self._d) * np.sqrt(eigvals) * scale
+                    samples_list.append(np.asarray(center, dtype=np.float64) + eigvecs @ noise)
+                samples = np.clip(
+                    np.asarray(samples_list, dtype=np.float64),
+                    self._lo_np[None, :],
+                    self._hi_np[None, :],
+                )
+                self._n_cmix += int(samples.shape[0])
+                return torch.tensor(samples, dtype=torch.float, device=self._device)
+        if self._cmix_candidate_center == "best" and self._win_x:
+            center = np.array(self._win_x[int(np.argmin(self._win_f))], float)
+        elif self._cmix_candidate_center == "elite" and elite_np is not None:
+            center = np.asarray(elite_np, float)
+        else:
+            center = self._es.m.detach().cpu().numpy().astype(np.float64)
+        scale = float(self._es.sigma)
+        noise = np.random.randn(count, self._d) * np.sqrt(eigvals)[None, :]
+        samples = center[None, :] + scale * (noise @ eigvecs.T)
+        samples = np.clip(samples, self._lo_np[None, :], self._hi_np[None, :])
+        self._n_cmix += int(samples.shape[0])
+        return torch.tensor(samples, dtype=torch.float, device=self._device)
+
+    def _cmix_shape_C(self) -> None:
+        w = self._cmix_w_eff
+        if self._last_JtJ is None or w is None or w <= 0.0:
+            return
+        d = self._d
+        try:
+            T = np.linalg.inv(self._last_JtJ + self._cmix_lambda * np.eye(d))
+        except np.linalg.LinAlgError:
+            self._cmix_fail += 1
+            return
+        if not np.all(np.isfinite(T)):
+            self._cmix_fail += 1
+            return
+        T = 0.5 * (T + T.T)
+        es = self._es
+        C = es.C.detach().cpu().numpy().astype(np.float64)
+        trC = float(np.trace(C))
+        trT = float(np.trace(T))
+        if trT <= 1e-30 or not np.isfinite(trC):
+            self._cmix_fail += 1
+            return
+        Tn = T * (trC / trT)
+        C_new = (1.0 - w) * C + w * Tn
+        C_new = 0.5 * (C_new + C_new.T)
+        es.C = torch.tensor(C_new, dtype=es.C.dtype, device=self._device)
+        self._safe_decompose()
+        self._n_cmix += 1
+
+    def _bounded_elite(self, fused_np: np.ndarray) -> Any:
+        es = self._es
+        x_e = torch.tensor(fused_np, dtype=torch.float, device=self._device)
+        y = (x_e - es.m) / es.sigma
+        if es.separable:
+            z = y / es.A
+        else:
+            z = torch.linalg.solve_triangular(es.A, y.unsqueeze(1), upper=False).squeeze(1)
+        znorm = float(torch.linalg.norm(z))
+        cap = self._kappa * self._sqrt_d
+        if znorm > cap and znorm > 1e-12:
+            z = z * (cap / znorm)
+            self._last_clip = cap / znorm
+        else:
+            self._last_clip = 1.0
+        if es.separable:
+            x_new = es.m + es.sigma * (es.A * z)
+        else:
+            x_new = es.m + es.sigma * (es.A @ z)
+        return torch.clamp(x_new, self._lo_t, self._hi_t)
+
+    def _update_es(self) -> None:
+        if not self._completed_trials:
+            return
+        self._harvest()
+        used = set(self.trials_used)
+        selected = [t for t in self._completed_trials if t.number not in used]
+        selected.sort(key=lambda t: t.number)
+        gen_before = self._generation
+        for i in range(len(selected) // self._popsize):
+            batch = selected[i * self._popsize : (i + 1) * self._popsize]
+            xs_np = np.array(
+                [[self._to_cma(n, t.params[n]) for n in self._param_names] for t in batch], float
+            )
+            ys_val = np.array([t.value for t in batch], float)
+            if self._study_direction == StudyDirection.MAXIMIZE:
+                ys_val = -ys_val
+            for t in batch:
+                self.trials_used.append(t.number)
+            self._cma_tell(xs_np, ys_val)
+            self._generation += 1
+            if self._verbose and self._generation % 5 == 0:
+                weff = self._cmix_w_eff if self._cmix_w_eff is not None else -1.0
+                print(
+                    f"[JANUS] gen={self._generation}, win={len(self._win_x)}, "
+                    f"sigma={float(self._es.sigma):.6f}, injected={self._n_injected}, "
+                    f"cmix={self._n_cmix}, w={weff:.4f}, "
+                    f"last_clip={self._last_clip:.3f}, gn_fail={self._gn_fail}, "
+                    f"cmix_fail={self._cmix_fail}, pseudo={self._last_pseudo_mode}, "
+                    f"pca_hit={self._pca_hits}, pca_fail={self._pca_fail}",
+                    flush=True,
+                )
+        if self._generation != gen_before:
+            self._pending_xs = None
+
+    def _cma_tell(self, xs_np: np.ndarray, fitness_np: np.ndarray) -> None:
+        es = self._es
+        xs = torch.tensor(xs_np, dtype=torch.float, device=self._device)
+        ys = (xs - es.m.unsqueeze(0)) / es.sigma
+        if es.separable:
+            zs = ys / es.A.unsqueeze(0)
+        else:
+            zs = torch.linalg.solve_triangular(es.A, ys.T, upper=False).T
+        fit = torch.tensor(fitness_np, dtype=torch.float, device=self._device)
+        indices = torch.argsort(fit)
+        ranks = torch.zeros_like(indices)
+        ranks[indices] = torch.arange(self._popsize, dtype=indices.dtype, device=indices.device)
+        assigned_weights = es.weights[ranks]
+        local_m_disp, shaped_m_disp = es.update_m(zs, ys, assigned_weights)
+        es.update_p_sigma(local_m_disp)
+        es.update_sigma()
+        h_sig = _h_sig(es.p_sigma, es.c_sigma, es._steps_count)
+        es.update_p_c(shaped_m_disp, h_sig)
+        es.update_C(zs, ys, assigned_weights, h_sig)
+        es._steps_count += 1
+        if es._steps_count % es.decompose_C_freq == 0:
+            self._safe_decompose()
+
+    def _safe_decompose(self) -> None:
+        es = self._es
+        try:
+            es.decompose_C()
+            return
+        except Exception:
+            pass
+        for jit in (1e-9, 1e-7, 1e-5, 1e-3, 1e-1):
+            try:
+                idx = torch.arange(self._d, device=self._device)
+                es.C[idx, idx] = es.C[idx, idx] + jit
+                es.decompose_C()
+                return
+            except Exception:
+                continue
+        es.C = torch.eye(self._d, device=self._device, dtype=es.C.dtype)
+        try:
+            es.decompose_C()
+        except Exception:
+            pass
+
+    def _generate(self) -> None:
+        elite = None
+        if self._generation % self._fuse_every == 0:
+            elite = self._assemble_gn()
+            if self._cmix_mode == "reshape":
+                self._cmix_shape_C()
+        _zs, _ys, xs = self._es.sample_distribution()
+        xs = torch.clamp(xs, self._lo_t.unsqueeze(0), self._hi_t.unsqueeze(0))
+        if self._cmix_mode in ("candidates", "candidate"):
+            n_cand = int(round(self._popsize * self._cmix_candidate_frac))
+            n_cand = max(0, min(self._popsize - 1, n_cand))
+            cand = self._cmix_candidate_samples(n_cand, elite_np=elite)
+            if cand is not None and cand.shape[0] > 0:
+                xs[-cand.shape[0] :] = cand
+        elif self._cmix_mode in ("portfolio", "hybrid"):
+            tail_budget = self._popsize - 1
+            n_cand = int(round(self._popsize * self._cmix_candidate_frac))
+            n_cand = max(0, min(tail_budget, n_cand))
+            cursor = self._popsize
+            cand = self._cmix_candidate_samples(n_cand, elite_np=elite)
+            if cand is not None and cand.shape[0] > 0:
+                cursor -= cand.shape[0]
+                xs[cursor : cursor + cand.shape[0]] = cand
+        if elite is not None:
+            xs[0] = self._bounded_elite(elite)
+            self._n_injected += 1
+        self._pending_xs = xs
+
+    def ask(self, idx: int) -> dict[str, Any]:
+        if self._pending_xs is None:
+            self._generate()
+        x = self._pending_xs[idx % self._pending_xs.shape[0]].detach().cpu().numpy()
+        if not np.all(np.isfinite(x)):
+            self._cmix_fail += 1
+            x = self._lo_np + self._rng.random(self._d) * (self._hi_np - self._lo_np)
+        x = np.clip(x, self._lo_np, self._hi_np)
+        return {n: self._from_cma(n, v) for n, v in zip(self._param_names, x)}
+
+    def _to_cma(self, name: str, val: Any) -> float:
+        dist = self._search_space[name]
+        if isinstance(dist, (IntDistribution, FloatDistribution)):
+            t = self._param_transforms[name]
+            return min(max((val - t["bias"]) * t["scale"], t["low"]), t["high"])
+        elif isinstance(dist, CategoricalDistribution):
+            return float(dist.choices.index(val))
+        return float(val)
+
+    def _from_cma(self, name: str, val: float) -> Any:
+        dist = self._search_space[name]
+        if isinstance(dist, (FloatDistribution, IntDistribution)):
+            t = self._param_transforms[name]
+            v = min(max(val / t["scale"] + t["bias"], dist.low), dist.high)
+            if isinstance(dist, IntDistribution):
+                if dist.step:
+                    v = np.round((v - dist.low) / dist.step) * dist.step + dist.low
+                return int(min(max(v, dist.low), dist.high))
+            else:
+                if dist.step:
+                    v = np.round((v - dist.low) / dist.step) * dist.step + dist.low
+                    return float(min(max(v, dist.low), dist.high))
+                return round(float(v), 10)
+        elif isinstance(dist, CategoricalDistribution):
+            return dist.choices[int(np.round(val))]
+        return val

--- a/package/samplers/janus/requirements.txt
+++ b/package/samplers/janus/requirements.txt
@@ -1,0 +1,5 @@
+optuna
+optunahub
+numpy
+torch
+evotorch

--- a/package/samplers/janus/tests/test_sampler.py
+++ b/package/samplers/janus/tests/test_sampler.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import numpy as np
+import optuna
+import optunahub
+import pytest
+
+
+pytest.importorskip("torch")
+pytest.importorskip("evotorch")
+
+
+JanusSampler = optunahub.load_local_module(
+    package="samplers/janus", registry_root="package/"
+).JanusSampler
+
+
+def objective(trial: optuna.Trial) -> float:
+    x = np.array([trial.suggest_float(f"x{i}", -5.0, 5.0) for i in range(4)])
+    residuals = (x - 0.5) ** 2
+    trial.set_user_attr("component_losses", residuals.tolist())
+    return float(residuals.sum())
+
+
+def test_sampler_runs_single_objective() -> None:
+    n_trials = 60
+    sampler = JanusSampler(seed=0, n_startup_trials=8)
+    study = optuna.create_study(direction="minimize", sampler=sampler)
+    study.optimize(objective, n_trials=n_trials)
+
+    assert len(study.trials) == n_trials
+    assert study.best_value is not None
+    assert set(study.best_params.keys()) == {f"x{i}" for i in range(4)}
+
+
+def test_sampler_falls_back_without_component_losses() -> None:
+    n_trials = 60
+
+    def objective_scalar(trial: optuna.Trial) -> float:
+        x = np.array([trial.suggest_float(f"x{i}", -5.0, 5.0) for i in range(4)])
+        return float(((x - 0.5) ** 2).sum())
+
+    sampler = JanusSampler(seed=1, n_startup_trials=8)
+    study = optuna.create_study(direction="minimize", sampler=sampler)
+    study.optimize(objective_scalar, n_trials=n_trials)
+
+    assert len(study.trials) == n_trials
+    assert study.best_value is not None

--- a/package/samplers/janus_moo/LICENSE
+++ b/package/samplers/janus_moo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hongyuan Yu, Pufan Xu, Jiaojiao Yi, Yiding Tian, Mingrui Sun, Jiayuan Lu, Changyuan Wen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/samplers/janus_moo/README.md
+++ b/package/samplers/janus_moo/README.md
@@ -1,0 +1,85 @@
+---
+author: Hongyuan Yu, Pufan Xu, Jiaojiao Yi, Yiding Tian, Mingrui Sun, Jiayuan Lu, Changyuan Wen
+title: JANUS Multi-objective Cmix Sampler
+description: NSGA-II augmented with JANUS Jacobian-aligned inverse-curvature infill for multi-objective black-box optimization.
+tags: [sampler, multi-objective, NSGA-II, Gauss-Newton, evolutionary algorithm]
+optuna_versions: [4.5.0]
+license: MIT License
+---
+
+## Abstract
+
+`JanusMooCmixSampler` is a plug-and-play, training-free multi-objective sampler that augments Optuna's NSGA-II host with JANUS-style, geometry-guided candidate generation (arXiv:2608.22862).
+
+Population optimizers such as NSGA-II drive search mainly through rank-based selection signals: a signal says one candidate dominates another, but not the local *direction* responsible for the improvement. JANUS recovers this missing local geometric signal **without replacing the host optimizer**. It estimates a local metric from the recent evaluation trace and occasionally replaces a child with inverse-curvature Gaussian samples drawn around the current Pareto front. NSGA-II keeps full control of Pareto selection, survival, and crowding — JANUS only contributes a few extra, metric-guided candidates.
+
+The metric is estimated from either a per-trial residual/component vector (recommended, exposed via `trial.set_user_attr("component_losses", [...])`) or a diagonal-quadratic scalar fallback fit on recent objective values. Defaults are intentionally conservative: short warm-up, low replacement probability, and a small normalized step size.
+
+## Class or Function Names
+
+- `JanusMooCmixSampler(*, population_size=100, seed=None, cmix_prob=0.02, cmix_window="auto", cmix_ridge=1.0, cmix_lambda=1.0, cmix_sigma=0.002, cmix_start_generation=3, cmix_start_trial=100, component_attr="component_losses", scalar_fallback="diag_quadratic", verbose=False, **kwargs)`
+  - `population_size`: Population size passed through to the NSGA-II host.
+  - `seed`: Seed for the random number generator.
+  - `cmix_prob`: Probability that a child is replaced by a JANUS infill candidate.
+  - `cmix_window`: Sliding window of recent completed trials used to estimate the local metric. `"auto"` uses `3 * population_size`.
+  - `cmix_ridge`: Ridge regularization for the metric regression.
+  - `cmix_lambda`: Levenberg–Marquardt damping added to the metric before inversion.
+  - `cmix_sigma`: Normalized step size (standard deviation) of the inverse-curvature Gaussian, in the unit hypercube.
+  - `cmix_start_trial`: Number of warm-up trials before JANUS infill engages. If `None`, it is derived from `cmix_start_generation` and `population_size`.
+  - `cmix_start_generation`: Warm-up measured in generations, used only when `cmix_start_trial=None`.
+  - `component_attr`: Trial user-attribute key holding the per-trial residual/component vector.
+  - `scalar_fallback`: Metric fallback when no component vector is available. Currently `"diag_quadratic"`.
+  - `verbose`: If `True`, prints periodic infill statistics.
+  - `**kwargs`: Additional keyword arguments forwarded to `optuna.samplers.NSGAIISampler`.
+
+Note that JANUS infill only samples non-conditional numerical (`FloatDistribution` / `IntDistribution`) parameters; other parameter types and the selection operator are handled entirely by the NSGA-II host.
+
+## Example
+
+```python
+import numpy as np
+import optuna
+import optunahub
+
+
+def objective(trial: optuna.Trial) -> tuple[float, float]:
+    x = np.array([trial.suggest_float(f"x{i}", 0.0, 1.0) for i in range(5)])
+    f1 = float(x[0])
+    g = 1.0 + 9.0 * float(np.mean(x[1:]))
+    f2 = g * (1.0 - np.sqrt(f1 / g))
+    # Optional: expose a residual/component vector so JANUS can sharpen its metric.
+    trial.set_user_attr("component_losses", [f1, float(f2)])
+    return f1, float(f2)
+
+
+JanusMooCmixSampler = optunahub.load_module(
+    package="samplers/janus_moo"
+).JanusMooCmixSampler
+
+sampler = JanusMooCmixSampler(population_size=50, seed=0, cmix_prob=0.05)
+study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
+study.optimize(objective, n_trials=400)
+print(f"Number of Pareto-optimal trials: {len(study.best_trials)}")
+```
+
+See `example.py` for a runnable version.
+
+## Others
+
+This sampler is the multi-objective component of JANUS (Jacobian-Aligned Newton-Unified Search).
+
+### Reference
+
+Hongyuan Yu, Pufan Xu, Jiaojiao Yi, Yiding Tian, Mingrui Sun, Jiayuan Lu, and Changyuan Wen. 2026. JANUS: Online Jacobian-Aligned Infill for Black-Box Optimization. arXiv preprint arXiv:2608.22862.
+
+### Bibtex
+
+```
+@article{yu2026janus,
+    title   = {JANUS: Online Jacobian-Aligned Infill for Black-Box Optimization},
+    author  = {Yu, Hongyuan and Xu, Pufan and Yi, Jiaojiao and Tian, Yiding and
+               Sun, Mingrui and Lu, Jiayuan and Wen, Changyuan},
+    journal = {arXiv preprint arXiv:2608.22862},
+    year    = {2026}
+}
+```

--- a/package/samplers/janus_moo/__init__.py
+++ b/package/samplers/janus_moo/__init__.py
@@ -1,0 +1,4 @@
+from .janus_moo_cmix import JanusMooCmixSampler
+
+
+__all__ = ["JanusMooCmixSampler"]

--- a/package/samplers/janus_moo/example.py
+++ b/package/samplers/janus_moo/example.py
@@ -1,0 +1,54 @@
+"""Multi-objective JANUS example.
+
+``JanusMooCmixSampler`` subclasses Optuna's NSGA-II. NSGA-II keeps full control
+of Pareto selection and survival; JANUS only occasionally replaces a child with
+inverse-curvature Gaussian samples estimated from the recent trace. This adds
+targeted, metric-guided exploration without changing the selection operator.
+
+Exposing a per-trial residual/component vector via
+``trial.set_user_attr("component_losses", [...])`` sharpens the local metric;
+otherwise a diagonal-quadratic scalar fallback is used.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import optuna
+import optunahub
+
+
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+
+def objective(trial: optuna.Trial) -> tuple[float, float]:
+    # ZDT1-style 2-objective problem in 5 dimensions.
+    d = 5
+    x = np.array([trial.suggest_float(f"x{i}", 0.0, 1.0) for i in range(d)])
+    f1 = float(x[0])
+    g = 1.0 + 9.0 * float(np.mean(x[1:]))
+    f2 = g * (1.0 - np.sqrt(f1 / g))
+
+    # Optional residual signal that sharpens JANUS's local curvature metric.
+    trial.set_user_attr("component_losses", [f1, float(f2)])
+
+    return f1, float(f2)
+
+
+if __name__ == "__main__":
+    JanusMooCmixSampler = optunahub.load_local_module(
+        package="samplers/janus_moo",
+        registry_root="./package",
+    ).JanusMooCmixSampler
+
+    sampler = JanusMooCmixSampler(
+        population_size=50,
+        seed=0,
+        cmix_prob=0.05,  # fraction of children replaced by JANUS infill
+        cmix_start_trial=100,  # warm-up before JANUS engages
+    )
+    study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
+    study.optimize(objective, n_trials=400)
+
+    print(f"Number of Pareto-optimal trials: {len(study.best_trials)}")
+    front = sorted((t.values for t in study.best_trials), key=lambda v: v[0])
+    print("Pareto front (first 5):", [(round(a, 3), round(b, 3)) for a, b in front[:5]])

--- a/package/samplers/janus_moo/janus_moo_cmix.py
+++ b/package/samplers/janus_moo/janus_moo_cmix.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import optuna
+from optuna.distributions import BaseDistribution
+from optuna.distributions import FloatDistribution
+from optuna.distributions import IntDistribution
+from optuna.samplers import NSGAIISampler
+from optuna.search_space import IntersectionSearchSpace
+from optuna.trial import FrozenTrial
+from optuna.trial import TrialState
+
+
+_EPS = 1e-12
+
+
+def _standardize(X: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    mu = X.mean(axis=0)
+    sd = X.std(axis=0)
+    sd = np.where(sd < _EPS, 1.0, sd)
+    return (X - mu) / sd, mu, sd
+
+
+def _fit_diag_quadratic_metric(X: np.ndarray, y: np.ndarray, ridge: float) -> np.ndarray | None:
+    X = np.asarray(X, dtype=float)
+    y = np.asarray(y, dtype=float).reshape(-1)
+    finite = np.all(np.isfinite(X), axis=1) & np.isfinite(y)
+    X = X[finite]
+    y = y[finite]
+    if X.ndim != 2 or X.shape[0] < 4 or X.shape[1] <= 0:
+        return None
+
+    Z, _mu, sd = _standardize(X)
+    design = np.c_[np.ones(Z.shape[0]), Z, 0.5 * Z * Z]
+    penalty = float(ridge) * np.eye(design.shape[1])
+    penalty[0, 0] = 0.0
+    try:
+        coef = np.linalg.solve(design.T @ design + penalty, design.T @ y)
+    except np.linalg.LinAlgError:
+        return None
+
+    hdiag = np.maximum(np.abs(coef[1 + Z.shape[1] :]), _EPS) / (sd * sd)
+    return np.diag(hdiag)
+
+
+def _fit_component_metric(
+    X: np.ndarray, components: np.ndarray, ridge: float
+) -> np.ndarray | None:
+    X = np.asarray(X, dtype=float)
+    S = np.asarray(components, dtype=float)
+    if S.ndim == 1:
+        S = S[:, None]
+    finite = np.all(np.isfinite(X), axis=1) & np.all(np.isfinite(S), axis=1)
+    X = X[finite]
+    S = S[finite]
+    if X.ndim != 2 or S.ndim != 2 or X.shape[0] != S.shape[0] or X.shape[0] < 4:
+        return None
+    if X.shape[1] <= 0 or S.shape[1] <= 0:
+        return None
+
+    Z, _mu, sd = _standardize(X)
+    S = np.sqrt(np.maximum(S, 0.0))
+    S = S - S.mean(axis=0)
+    try:
+        AinvZt = np.linalg.solve(Z.T @ Z + float(ridge) * np.eye(Z.shape[1]), Z.T)
+    except np.linalg.LinAlgError:
+        return None
+    W = (AinvZt @ S).T
+    J = W / sd[None, :]
+    metric = J.T @ J
+    if not np.all(np.isfinite(metric)):
+        return None
+    return 0.5 * (metric + metric.T)
+
+
+def _nondominated_indices(values: np.ndarray) -> np.ndarray:
+    values = np.asarray(values, dtype=float)
+    finite = np.all(np.isfinite(values), axis=1)
+    idx = np.where(finite)[0]
+    if idx.size == 0:
+        return np.arange(values.shape[0])
+    vals = values[idx]
+    keep = np.ones(vals.shape[0], dtype=bool)
+    for i, point in enumerate(vals):
+        if not keep[i]:
+            continue
+        dominated = np.all(vals <= point, axis=1) & np.any(vals < point, axis=1)
+        dominated[i] = False
+        keep[dominated] = False
+    return idx[keep]
+
+
+def _crowding_like(values: np.ndarray) -> np.ndarray:
+    values = np.asarray(values, dtype=float)
+    n, m = values.shape
+    dist = np.zeros(n, dtype=float)
+    if n <= 2:
+        dist[:] = np.inf
+        return dist
+    for j in range(m):
+        order = np.argsort(values[:, j], kind="mergesort")
+        dist[order[0]] = np.inf
+        dist[order[-1]] = np.inf
+        span = values[order[-1], j] - values[order[0], j]
+        if not np.isfinite(span) or span <= _EPS:
+            continue
+        dist[order[1:-1]] += (values[order[2:], j] - values[order[:-2], j]) / span
+    return dist
+
+
+class JanusMooCmixSampler(NSGAIISampler):
+    """NSGA-II selection with JANUS-style Cmix candidate generation for MOO.
+
+    NSGA-II still owns Pareto selection. This sampler occasionally replaces a
+    child with inverse-curvature Gaussian samples estimated from either
+    trial.user_attrs['component_losses'] or a diagonal quadratic scalar fallback.
+
+    The defaults are intentionally conservative: short warm-up, low replacement
+    probability, small normalized step size, and Pareto-front center selection.
+    For Optuna-scale runs (often ~1000 trials), the warm-up is measured in a few
+    populations rather than the long 60-generation delay used by 20k-evaluation
+    pymoo experiments.
+    """
+
+    def __init__(
+        self,
+        *,
+        population_size: int = 100,
+        seed: int | None = None,
+        cmix_prob: float = 0.02,
+        cmix_window: int | str = "auto",
+        cmix_ridge: float = 1.0,
+        cmix_lambda: float = 1.0,
+        cmix_sigma: float = 0.002,
+        cmix_start_generation: int = 3,
+        cmix_start_trial: int | None = 100,
+        component_attr: str = "component_losses",
+        scalar_fallback: str = "diag_quadratic",
+        verbose: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(population_size=population_size, seed=seed, **kwargs)
+        self._verbose = bool(verbose)
+        self._cmix_prob = float(cmix_prob)
+        self._cmix_window = (
+            3 * int(population_size) if str(cmix_window).lower() == "auto" else int(cmix_window)
+        )
+        self._cmix_ridge = float(cmix_ridge)
+        self._cmix_lambda = float(cmix_lambda)
+        self._cmix_sigma = float(cmix_sigma)
+        if cmix_start_trial is None:
+            self._cmix_start_trial = max(
+                self._cmix_window, max(0, int(cmix_start_generation)) * int(population_size)
+            )
+        else:
+            self._cmix_start_trial = max(0, int(cmix_start_trial))
+        self._component_attr = component_attr
+        self._scalar_fallback = str(scalar_fallback or "diag_quadratic").lower()
+        self._search_space = IntersectionSearchSpace()
+        self._cmix_rng = np.random.default_rng(seed)
+        self._last_cmix_mode = "none"
+        self._cmix_hits = 0
+        self._cmix_fail = 0
+
+    def infer_relative_search_space(
+        self,
+        study: optuna.study.Study,
+        trial: FrozenTrial,
+    ) -> dict[str, BaseDistribution]:
+        return {
+            name: dist
+            for name, dist in self._search_space.calculate(study).items()
+            if not dist.single()
+        }
+
+    def sample_relative(
+        self,
+        study: optuna.study.Study,
+        trial: FrozenTrial,
+        search_space: dict[str, BaseDistribution],
+    ) -> dict[str, Any]:
+        nsga_params = super().sample_relative(study, trial, search_space)
+        if trial.number < self._cmix_start_trial:
+            return nsga_params
+        if len(search_space) > 1 and self._cmix_rng.random() < self._cmix_prob:
+            params = self._sample_cmix(study, search_space)
+            if params:
+                self._cmix_hits += 1
+                return params
+            self._cmix_fail += 1
+        return nsga_params
+
+    def _sample_cmix(
+        self,
+        study: optuna.study.Study,
+        search_space: dict[str, BaseDistribution],
+    ) -> dict[str, Any] | None:
+        param_names = sorted(search_space.keys())
+        transforms = self._build_transforms(search_space, param_names)
+        if transforms is None:
+            return None
+
+        trials = [
+            trial
+            for trial in study._get_trials(deepcopy=False, use_cache=True)
+            if trial.state == TrialState.COMPLETE and trial.values is not None
+        ]
+        rows: list[list[float]] = []
+        used_trials: list[FrozenTrial] = []
+        components: list[list[float]] = []
+        has_components = True
+        for completed in trials[-max(4, self._cmix_window) :]:
+            if not all(name in completed.params for name in param_names):
+                continue
+            try:
+                rows.append(
+                    [
+                        self._to_norm(completed.params[name], transforms[name])
+                        for name in param_names
+                    ]
+                )
+            except (TypeError, ValueError):
+                rows.pop()
+                continue
+            used_trials.append(completed)
+            component_value = completed.user_attrs.get(self._component_attr)
+            if component_value is None:
+                has_components = False
+            elif has_components:
+                try:
+                    components.append([float(v) for v in component_value])
+                except (TypeError, ValueError):
+                    has_components = False
+
+        if len(rows) < 4:
+            return None
+        X = np.asarray(rows, dtype=float)
+        metric = None
+        if has_components and len(components) == len(rows):
+            metric = _fit_component_metric(
+                X, np.asarray(components, dtype=float), self._cmix_ridge
+            )
+            self._last_cmix_mode = "component_losses"
+        if metric is None and self._scalar_fallback in ("diag_quadratic", "diagq", "quad"):
+            values = np.asarray(
+                [self._scalar_value(study, trial) for trial in used_trials], dtype=float
+            )
+            metric = _fit_diag_quadratic_metric(X, values, self._cmix_ridge)
+            self._last_cmix_mode = "diag_quadratic"
+        if metric is None:
+            self._last_cmix_mode = "none"
+            return None
+
+        center = self._choose_center(study, used_trials, param_names, transforms)
+        if center is None:
+            center = X.mean(axis=0)
+        cov = self._inverse_metric_cov(metric, X.shape[1])
+        if cov is None:
+            return None
+        for _ in range(8):
+            sample = self._cmix_rng.multivariate_normal(center, cov)
+            sample = np.clip(sample, 0.0, 1.0)
+            params = self._from_norm_vector(sample, search_space, param_names, transforms)
+            if params is not None:
+                return params
+        return None
+
+    def _build_transforms(
+        self,
+        search_space: dict[str, BaseDistribution],
+        param_names: list[str],
+    ) -> dict[str, dict[str, Any]] | None:
+        transforms: dict[str, dict[str, Any]] = {}
+        for name in param_names:
+            dist = search_space[name]
+            if not isinstance(dist, (FloatDistribution, IntDistribution)):
+                return None
+            low = float(dist.low)
+            high = float(dist.high)
+            if not np.isfinite(low) or not np.isfinite(high) or high <= low:
+                return None
+            transforms[name] = {
+                "low": low,
+                "high": high,
+                "step": getattr(dist, "step", None),
+                "is_int": isinstance(dist, IntDistribution),
+            }
+        return transforms
+
+    def _to_norm(self, value: Any, transform: dict[str, Any]) -> float:
+        return (float(value) - transform["low"]) / (transform["high"] - transform["low"])
+
+    def _from_norm_vector(
+        self,
+        sample: np.ndarray,
+        search_space: dict[str, BaseDistribution],
+        param_names: list[str],
+        transforms: dict[str, dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        params: dict[str, Any] = {}
+        for idx, name in enumerate(param_names):
+            transform = transforms[name]
+            value = transform["low"] + float(sample[idx]) * (transform["high"] - transform["low"])
+            dist = search_space[name]
+            step = transform.get("step")
+            if step is not None:
+                value = transform["low"] + round((value - transform["low"]) / float(step)) * float(
+                    step
+                )
+            if transform["is_int"]:
+                value = int(round(value))
+                value = int(min(max(value, transform["low"]), transform["high"]))
+            else:
+                value = float(min(max(value, transform["low"]), transform["high"]))
+            if not dist._contains(dist.to_internal_repr(value)):
+                return None
+            params[name] = value
+        return params
+
+    def _scalar_value(self, study: optuna.study.Study, trial: FrozenTrial) -> float:
+        values = np.asarray(trial.values, dtype=float)
+        values = np.where(np.isfinite(values), values, 1.0)
+        return float(np.mean(values))
+
+    def _choose_center(
+        self,
+        study: optuna.study.Study,
+        trials: list[FrozenTrial],
+        param_names: list[str],
+        transforms: dict[str, dict[str, Any]],
+    ) -> np.ndarray | None:
+        complete = [trial for trial in trials if all(name in trial.params for name in param_names)]
+        if not complete:
+            return None
+        value_rows = [trial.values for trial in complete if trial.values is not None]
+        if len(value_rows) == len(complete) and value_rows:
+            values = np.asarray(value_rows, dtype=float)
+            front_idx = _nondominated_indices(values)
+            front = [complete[int(i)] for i in front_idx]
+            if len(front) > 1:
+                cd = _crowding_like(values[front_idx])
+                order = np.argsort(-cd, kind="mergesort")
+                top = [front[int(i)] for i in order[: max(1, min(5, len(front)))]]
+            else:
+                top = front
+        else:
+            top = []
+        if not top:
+            ranked = sorted(complete, key=lambda trial: self._scalar_value(study, trial))
+            top = ranked[: max(1, min(5, len(ranked)))]
+        rows = [
+            [self._to_norm(trial.params[name], transforms[name]) for name in param_names]
+            for trial in top
+        ]
+        return np.asarray(rows, dtype=float).mean(axis=0)
+
+    def _inverse_metric_cov(self, metric: np.ndarray, dim: int) -> np.ndarray | None:
+        try:
+            cov = np.linalg.inv(metric + self._cmix_lambda * np.eye(dim))
+        except np.linalg.LinAlgError:
+            return None
+        cov = 0.5 * (cov + cov.T)
+        trace = float(np.trace(cov))
+        if not np.isfinite(trace) or trace <= _EPS:
+            return None
+        cov *= (max(self._cmix_sigma, _EPS) ** 2 * dim) / trace
+        cov += 1e-8 * np.eye(dim)
+        return cov
+
+    def after_trial(
+        self,
+        study: optuna.study.Study,
+        trial: FrozenTrial,
+        state: TrialState,
+        values: Sequence[float] | None,
+    ) -> None:
+        population_size = self._population_size or 1
+        period = max(1, int(population_size))
+        if self._verbose and trial.number > 0 and trial.number % period == 0:
+            print(
+                f"[JANUS-MOO-CMIX] trial={trial.number}, hit={self._cmix_hits}, "
+                f"fail={self._cmix_fail}, mode={self._last_cmix_mode}",
+                flush=True,
+            )
+        return super().after_trial(study, trial, state, values)

--- a/package/samplers/janus_moo/tests/test_sampler.py
+++ b/package/samplers/janus_moo/tests/test_sampler.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import numpy as np
+import optuna
+import optunahub
+
+
+JanusMooCmixSampler = optunahub.load_local_module(
+    package="samplers/janus_moo", registry_root="package/"
+).JanusMooCmixSampler
+
+
+def objective(trial: optuna.Trial) -> tuple[float, float]:
+    x = np.array([trial.suggest_float(f"x{i}", 0.0, 1.0) for i in range(4)])
+    f1 = float(x[0])
+    g = 1.0 + 9.0 * float(np.mean(x[1:]))
+    f2 = g * (1.0 - np.sqrt(f1 / g))
+    return f1, float(f2)
+
+
+def test_sampler_runs_multi_objective() -> None:
+    n_trials = 60
+    sampler = JanusMooCmixSampler(
+        population_size=10,
+        seed=0,
+        cmix_prob=0.2,
+        cmix_start_trial=20,
+    )
+    study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
+    study.optimize(objective, n_trials=n_trials)
+
+    assert len(study.trials) == n_trials
+    assert len(study.best_trials) >= 1
+    for trial in study.best_trials:
+        assert trial.values is not None
+        assert len(trial.values) == 2
+
+
+def test_sampler_uses_component_losses() -> None:
+    n_trials = 60
+
+    def objective_with_components(trial: optuna.Trial) -> tuple[float, float]:
+        f1, f2 = objective(trial)
+        trial.set_user_attr("component_losses", [f1, f2])
+        return f1, f2
+
+    sampler = JanusMooCmixSampler(
+        population_size=10,
+        seed=1,
+        cmix_prob=0.2,
+        cmix_start_trial=20,
+    )
+    study = optuna.create_study(directions=["minimize", "minimize"], sampler=sampler)
+    study.optimize(objective_with_components, n_trials=n_trials)
+
+    assert len(study.trials) == n_trials
+    assert len(study.best_trials) >= 1


### PR DESCRIPTION
## Contributor Agreements

Please read the [contributor agreements](https://github.com/optuna/optunahub-registry/blob/main/CONTRIBUTING.md#contributor-agreements) and if you agree, please click the checkbox below.

- [x] I agree to the contributor agreements.

> [!TIP]
> Please follow the [Quick TODO list](https://github.com/optuna/optunahub-registry/tree/main?tab=readme-ov-file#quick-todo-list-towards-contribution) to smoothly merge your PR.

## Motivation

JANUS (Jacobian-Aligned Newton-Unified Search, arXiv:2608.22862) is a plug-and-play, training-free family of samplers that recovers the local geometric signal population optimizers discard: from a single estimated Jacobian `J`, it assembles a Gauss-Newton exploitation step and an inverse-curvature (CMIX) exploration tail from the recent evaluation trace, without replacing the host optimizer. This PR contributes both halves of the method as OptunaHub packages.

## Description of the changes

Adds two self-contained packages (kept separate, one sampler each, per the registry convention):

- **`package/samplers/janus`** — `JanusSampler`, the single-objective sampler. A CMA-ES host (evotorch backend) that every few generations injects a bounded Gauss-Newton elite plus inverse-curvature CMIX candidates. Requires the optional backend `torch` + `evotorch` (declared in `requirements.txt`).
- **`package/samplers/janus_moo`** — `JanusMooCmixSampler`, the multi-objective sampler. Subclasses Optuna's `NSGAIISampler`; NSGA-II keeps full control of Pareto selection while JANUS occasionally replaces a child with inverse-curvature Gaussian samples. Depends only on `optuna` + `numpy`.

Both estimate the local metric from a per-trial residual/component vector when available (`trial.set_user_attr("component_losses", [...])`), falling back to a local quadratic fit otherwise. Each package ships a README (with the required frontmatter), an MIT `LICENSE`, a runnable `example.py`, and unit tests. All files pass the repo's pre-commit suite (ruff, ruff-format, mypy strict, mdformat).

The upstream JANUS reference implementation is Apache-2.0; these contributions are submitted under the MIT license as required, and I certify I have the right to do so.

## TODO List towards PR Merge

- [x] Copy `./template/` to create your package
- [x] Replace `<COPYRIGHT HOLDER>` in `LICENSE` of your package with your name
- [x] Fill out `README.md` in your package
- [x] Add import statements of your function or class names to be used in `__init__.py`
- [x] (Optional) Add `from __future__ import annotations` at the head of any Python files that include typing to support older Python versions
- [x] Apply the formatter based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
- [x] Check whether your module works as intended based on the tips in [`README.md`](https://github.com/optuna/optunahub-registry/tree/main)
